### PR TITLE
fix(registry): extract skill content from ZIP archive

### DIFF
--- a/apps/registry/src/utils/skill-content.ts
+++ b/apps/registry/src/utils/skill-content.ts
@@ -1,0 +1,36 @@
+import AdmZip from 'adm-zip';
+
+/**
+ * Extract the body content from SKILL.md inside a .skill ZIP archive.
+ *
+ * Looks for a `SKILL.md` entry (nested or root), parses YAML frontmatter,
+ * and returns the body text after the closing `---` delimiter.
+ *
+ * Returns `undefined` if the ZIP contains no SKILL.md, the file has no
+ * frontmatter body, or the buffer is not a valid ZIP.
+ */
+export function extractSkillContent(zipBuffer: Buffer): string | undefined {
+  let zip: AdmZip;
+  try {
+    zip = new AdmZip(zipBuffer);
+  } catch {
+    return undefined;
+  }
+
+  const skillEntry = zip
+    .getEntries()
+    .find((e) => e.entryName.endsWith('/SKILL.md') || e.entryName === 'SKILL.md');
+
+  if (!skillEntry) {
+    return undefined;
+  }
+
+  const fileContent = skillEntry.getData().toString('utf-8');
+  const fmMatch = fileContent.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/);
+  if (!fmMatch?.[1]) {
+    return undefined;
+  }
+
+  const body = fmMatch[1].trim();
+  return body.length > 0 ? body : undefined;
+}

--- a/apps/registry/tests/skill-content.test.ts
+++ b/apps/registry/tests/skill-content.test.ts
@@ -1,0 +1,90 @@
+import AdmZip from 'adm-zip';
+import { describe, expect, it } from 'vitest';
+import { extractSkillContent } from '../src/utils/skill-content.js';
+
+function makeZip(entries: Record<string, string>): Buffer {
+  const zip = new AdmZip();
+  for (const [name, content] of Object.entries(entries)) {
+    zip.addFile(name, Buffer.from(content, 'utf-8'));
+  }
+  return zip.toBuffer();
+}
+
+const SKILL_MD = `---
+name: my-skill
+version: 1.0.0
+---
+This is the skill body content.
+
+It has multiple paragraphs.`;
+
+describe('extractSkillContent', () => {
+  it('extracts body from nested SKILL.md (skill-pack structure)', () => {
+    const buf = makeZip({ 'my-skill/SKILL.md': SKILL_MD });
+    const result = extractSkillContent(buf);
+    expect(result).toBe('This is the skill body content.\n\nIt has multiple paragraphs.');
+  });
+
+  it('extracts body from root SKILL.md', () => {
+    const buf = makeZip({ 'SKILL.md': SKILL_MD });
+    const result = extractSkillContent(buf);
+    expect(result).toBe('This is the skill body content.\n\nIt has multiple paragraphs.');
+  });
+
+  it('returns undefined when ZIP has no SKILL.md', () => {
+    const buf = makeZip({ 'README.md': '# Hello' });
+    expect(extractSkillContent(buf)).toBeUndefined();
+  });
+
+  it('returns undefined for frontmatter-only SKILL.md (no body)', () => {
+    const buf = makeZip({
+      'SKILL.md': `---
+name: my-skill
+version: 1.0.0
+---`,
+    });
+    expect(extractSkillContent(buf)).toBeUndefined();
+  });
+
+  it('returns undefined for empty body after frontmatter', () => {
+    const buf = makeZip({
+      'SKILL.md': `---
+name: my-skill
+---
+
+
+`,
+    });
+    expect(extractSkillContent(buf)).toBeUndefined();
+  });
+
+  it('handles CRLF line endings in frontmatter', () => {
+    const crlf = '---\r\nname: my-skill\r\n---\r\nBody with CRLF.';
+    const buf = makeZip({ 'SKILL.md': crlf });
+    expect(extractSkillContent(buf)).toBe('Body with CRLF.');
+  });
+
+  it('returns undefined for non-ZIP buffer', () => {
+    const garbage = Buffer.from('this is not a zip file');
+    expect(extractSkillContent(garbage)).toBeUndefined();
+  });
+
+  it('returns undefined for SKILL.md with no frontmatter', () => {
+    const buf = makeZip({ 'SKILL.md': 'Just some markdown without frontmatter.' });
+    expect(extractSkillContent(buf)).toBeUndefined();
+  });
+
+  it('picks first match when multiple SKILL.md files exist', () => {
+    const zip = new AdmZip();
+    zip.addFile(
+      'a-skill/SKILL.md',
+      Buffer.from('---\nname: first\n---\nFirst body.')
+    );
+    zip.addFile(
+      'b-skill/SKILL.md',
+      Buffer.from('---\nname: second\n---\nSecond body.')
+    );
+    const result = extractSkillContent(zip.toBuffer());
+    expect(result).toBe('First body.');
+  });
+});


### PR DESCRIPTION
## Summary

- Skill `.skill` files are ZIP archives containing `SKILL.md`, but the announce endpoint was reading the ZIP binary as raw UTF-8 text and regex-matching for YAML frontmatter — which always failed silently, storing `content` as `null`
- Skill detail pages (e.g., `/skills/@nimblebraininc/upjack-app-builder`) only showed tags/metadata with no skill body content
- Now uses `AdmZip` (already a dependency) to extract `SKILL.md` from the archive before parsing frontmatter

## Test plan

- [ ] Verify `pnpm typecheck` and `pnpm test` pass (65/65 tests passing locally)
- [ ] Re-announce an existing skill (e.g., `upjack-app-builder`) and verify the API returns non-null `content`
- [ ] Confirm the skill detail page renders the markdown body on the Overview tab