### PR TITLE
ci: add automated npm publish workflow for CLI

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,56 @@
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - 'cli-v*'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @nimblebrain/mpak... build
+      - run: pnpm --filter @nimblebrain/mpak lint
+      - run: pnpm --filter @nimblebrain/mpak typecheck
+      - run: pnpm --filter @nimblebrain/mpak test
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/cli-v}"
+          PKG_VERSION=$(node -e "console.log(require('./packages/cli/package.json').version)")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) != package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Build
+        run: pnpm --filter @nimblebrain/mpak... build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        working-directory: packages/cli


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically publish `@nimblebrain/mpak` (CLI) to npm on `cli-v*` tags
- Mirrors the existing `sdk-typescript-publish.yml` pattern: verify job (lint, typecheck, test) → publish job (OIDC provenance)
- Builds full dependency chain (`@nimblebrain/mpak...`) to include schemas and SDK

## Release workflow
```bash
# 1. Bump version in packages/cli/package.json
# 2. Commit and push
# 3. Tag and push
git tag cli-v0.2.1 && git push --tags
```

## Test plan
- [ ] Verify workflow file is valid YAML and triggers only on `cli-v*` tags
- [ ] Confirm `npm` environment exists in repo settings (already used by SDK workflow)
- [ ] Test with a real tag after merge