### PR TITLE
Add version field to SkillFrontmatterSchema

### DIFF
--- a/apps/registry/src/schemas/generated/skill.ts
+++ b/apps/registry/src/schemas/generated/skill.ts
@@ -101,6 +101,7 @@ export const SkillFrontmatterSchema = z.object({
   description: SkillDescriptionSchema,
 
   // Optional (official spec - informational pass-through)
+  version: z.string().optional(),
   license: z.string().optional(),
   compatibility: z.string().max(500).optional(),
   'allowed-tools': z.string().optional(), // space-delimited, experimental

--- a/packages/schemas/src/skill.ts
+++ b/packages/schemas/src/skill.ts
@@ -79,6 +79,7 @@ export const SkillDiscoveryMetadataSchema = z
 export const SkillFrontmatterSchema = z.object({
   name: SkillNameSchema,
   description: SkillDescriptionSchema,
+  version: z.string().optional(),
   license: z.string().optional(),
   compatibility: z.string().max(500).optional(),
   "allowed-tools": z.string().optional(),


### PR DESCRIPTION
## Summary
- Add optional `version` field to `SkillFrontmatterSchema` in both source and generated schemas
- Skills legitimately include `version` in YAML frontmatter, but `additionalProperties: false` (from Zod strict objects) rejected it
- This caused contributor-toolkit CI validation to fail on every push since the v0.4.0 release

## Test plan
- [ ] `pnpm --filter @nimblebrain/mpak-schemas typecheck` passes
- [ ] `pnpm --filter @nimblebrain/mpak-registry typecheck` passes
- [ ] After deploy, `validate.sh` in contributor-toolkit passes against live API