### PR TITLE
feat(cli): set MPAK_WORKSPACE env var on mpak run

### DIFF
--- a/apps/docs/src/content/docs/bundles/manifest.mdx
+++ b/apps/docs/src/content/docs/bundles/manifest.mdx
@@ -140,6 +140,20 @@ Use `${__dirname}` to reference the bundle's extraction directory:
 }
 ```
 
+### Runtime Environment Variables
+
+`mpak run` automatically sets environment variables that bundles can use at runtime:
+
+| Variable | Description |
+|----------|-------------|
+| `MPAK_WORKSPACE` | Project-local directory for persistent data (defaults to `$CWD/.mpak`). Use this instead of relative paths for any data that should survive across restarts. |
+
+```python
+import os
+workspace = os.environ.get("MPAK_WORKSPACE", ".")
+entities_dir = os.path.join(workspace, "entities")
+```
+
 ## user_config
 
 Define configuration that users need to provide (API keys, etc.):

--- a/apps/docs/src/content/docs/cli/run.mdx
+++ b/apps/docs/src/content/docs/cli/run.mdx
@@ -56,6 +56,31 @@ See the [Integrations](/integrations/claude-code) section for setting up mpak bu
 - [Claude Code](/integrations/claude-code) - One command: `claude mcp add --transport stdio echo -- mpak run @nimblebraininc/echo`
 - [Claude Desktop](/integrations/claude-desktop) - JSON config file
 
+## Environment Variables
+
+When `mpak run` spawns a bundle, it sets the following environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MPAK_WORKSPACE` | `$CWD/.mpak` | Project-local directory for stateful data. Bundles should read/write persistent data here instead of using relative paths. |
+
+Override the workspace directory:
+
+```bash
+MPAK_WORKSPACE=/data/my-project mpak run @nimblebraininc/leadgen
+```
+
+Bundles access it via standard environment variable APIs:
+
+```python
+import os
+workspace = os.environ.get("MPAK_WORKSPACE", ".")
+```
+
+```typescript
+const workspace = process.env.MPAK_WORKSPACE ?? ".";
+```
+
 ## Configuration
 
 Some bundles require configuration (API keys, etc.). See [mpak config](/cli/config) for storing configuration values.

--- a/packages/cli/src/commands/packages/run.test.ts
+++ b/packages/cli/src/commands/packages/run.test.ts
@@ -5,6 +5,7 @@ import {
   parsePackageSpec,
   getCacheDir,
   resolveArgs,
+  resolveWorkspace,
   substituteUserConfig,
   substituteEnvVars,
   getLocalCacheDir,
@@ -310,5 +311,25 @@ describe("localBundleNeedsExtract", () => {
     expect(
       localBundleNeedsExtract("/any/path.mcpb", "/tmp"),
     ).toBe(true);
+  });
+});
+
+describe("resolveWorkspace", () => {
+  it("defaults to $cwd/.mpak when no override", () => {
+    expect(resolveWorkspace(undefined, "/home/user/project")).toBe(
+      join("/home/user/project", ".mpak"),
+    );
+  });
+
+  it("uses override when provided", () => {
+    expect(
+      resolveWorkspace("/data/custom", "/home/user/project"),
+    ).toBe("/data/custom");
+  });
+
+  it("treats empty string as no override", () => {
+    expect(resolveWorkspace("", "/home/user/project")).toBe(
+      join("/home/user/project", ".mpak"),
+    );
   });
 });

--- a/packages/cli/src/commands/packages/run.ts
+++ b/packages/cli/src/commands/packages/run.ts
@@ -197,6 +197,17 @@ export function resolveArgs(args: string[], cacheDir: string): string[] {
 }
 
 /**
+ * Resolve the MPAK_WORKSPACE value.
+ * If an override is provided (via env), use it. Otherwise default to $cwd/.mpak.
+ */
+export function resolveWorkspace(
+  override: string | undefined,
+  cwd: string,
+): string {
+  return override || join(cwd, ".mpak");
+}
+
+/**
  * Substitute ${user_config.*} placeholders in a string
  * @example substituteUserConfig('${user_config.api_key}', { api_key: 'secret' }) => 'secret'
  */
@@ -655,6 +666,10 @@ export async function handleRun(
     default:
       throw new Error(`Unsupported server type: ${type as string}`);
   }
+
+  // Provide a project-local workspace directory for stateful bundles.
+  // Defaults to $CWD/.mpak — user can override via MPAK_WORKSPACE in their environment.
+  env["MPAK_WORKSPACE"] = resolveWorkspace(env["MPAK_WORKSPACE"], process.cwd());
 
   // Spawn with stdio passthrough for MCP
   const child = spawn(command, args, {


### PR DESCRIPTION
## Summary

- Sets `MPAK_WORKSPACE` env var (defaults to `$CWD/.mpak`) when spawning bundles via `mpak run`
- User can override: `MPAK_WORKSPACE=/data/custom mpak run @scope/app`
- Extracted `resolveWorkspace()` helper with unit tests
- Updated CLI and manifest docs

Fixes #30

## Test plan

- [ ] `resolveWorkspace` unit tests pass (default, override, empty string cases)
- [ ] Verify `MPAK_WORKSPACE` is set when running a bundle: `mpak run @nimblebraininc/echo` then check env
- [ ] Verify override works: `MPAK_WORKSPACE=/tmp mpak run @nimblebraininc/echo`