### PR TITLE
Add *.tgz to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 dist/
 build/
 *.tsbuildinfo
+*.tgz
 .astro/
 
 # Turborepo


### PR DESCRIPTION
## Summary
- Add `*.tgz` to `.gitignore` to prevent `pnpm pack` artifacts from being committed
- Cleans up leftover `packages/cli/nimblebrain-mpak-0.2.0.tgz` from a prior publish

## Test plan
- [ ] Verify `pnpm pack` output is no longer picked up by `git status`