### PR TITLE
Rename --update to --no-cache on mpak run

### DIFF
--- a/packages/cli/src/commands/packages/run.ts
+++ b/packages/cli/src/commands/packages/run.ts
@@ -25,7 +25,7 @@ import type { CacheMetadata } from "../../utils/cache.js";
 import { ConfigManager } from "../../utils/config-manager.js";
 
 export interface RunOptions {
-  update?: boolean;
+  noCache?: boolean;
   local?: string; // Path to local .mcpb file
 }
 
@@ -367,7 +367,7 @@ export async function handleRun(
 
     cacheDir = getLocalCacheDir(bundlePath);
     const needsExtract =
-      options.update ||
+      options.noCache ||
       localBundleNeedsExtract(bundlePath, cacheDir);
 
     if (needsExtract) {
@@ -407,12 +407,12 @@ export async function handleRun(
     cachedMeta = getCacheMetadata(cacheDir);
 
     // Check if we have a cached version
-    if (cachedMeta && !options.update) {
+    if (cachedMeta && !options.noCache) {
       if (requestedVersion) {
         // Specific version requested - check if cached version matches
         needsPull = !isSemverEqual(cachedMeta.version, requestedVersion);
       } else {
-        // Latest requested - use cache (user can --update to refresh)
+        // Latest requested - use cache (user can --no-cache to refresh)
         needsPull = false;
       }
     }
@@ -424,7 +424,7 @@ export async function handleRun(
       if (
         cachedMeta &&
         isSemverEqual(cachedMeta.version, downloadInfo.bundle.version) &&
-        !options.update
+        !options.noCache
       ) {
         needsPull = false;
       }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -64,9 +64,10 @@ export function createProgram(): Command {
   program
     .command("run [package]")
     .description('Run an MCP server (alias for "bundle run")')
-    .option("--update", "Force re-download even if cached")
+    .option("--no-cache", "Always re-extract, skip cache")
     .option("-l, --local <path>", "Run a local .mcpb bundle file")
     .action(async (packageSpec, options) => {
+      options.noCache = options.cache === false;
       await handleRun(packageSpec || "", options);
     });
 
@@ -130,9 +131,10 @@ export function createProgram(): Command {
   bundle
     .command("run [package]")
     .description("Run an MCP server from the registry")
-    .option("--update", "Force re-download even if cached")
+    .option("--no-cache", "Always re-extract, skip cache")
     .option("-l, --local <path>", "Run a local .mcpb bundle file")
     .action(async (packageSpec, options) => {
+      options.noCache = options.cache === false;
       await handleRun(packageSpec || "", options);
     });
 


### PR DESCRIPTION
## Summary

- Renames the `--update` flag to `--no-cache` on `mpak run` / `mpak bundle run` for better developer ergonomics
- `--no-cache` is the idiomatic flag name (npm, pip, docker) and better describes the behavior — especially with `--local` where there's no registry update involved
- Renames `RunOptions.update` to `RunOptions.noCache` and normalizes Commander.js `--no-*` boolean in both action handlers

## Test plan

- [x] `pnpm build` passes
- [x] All 133 tests pass
- [ ] `mpak run --help` shows `--no-cache`, no `--update`
- [ ] `mpak run --no-cache --local <bundle>` forces re-extraction