### PR TITLE
feat(sdk): add userConfig option to prepareServer

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblebrain/mpak-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "TypeScript SDK for mpak registry - MCPB bundles and Agent Skills",
   "author": "NimbleBrain Inc <engineering@mpak.dev>",
   "license": "Apache-2.0",

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -63,6 +63,10 @@ export interface PrepareServerOptions {
    * for example, when credentials live in a workspace-scoped secret store
    * managed by the host runtime.
    *
+   * Values must be strings. Manifest fields typed as `number` or `boolean`
+   * must be stringified by the caller (e.g. `String(port)`) — matching how
+   * stored `config.json` values and manifest defaults are handled internally.
+   *
    * Backward compatible: omitting this option (or passing an empty object)
    * preserves the existing behavior of reading exclusively from stored config.
    */

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -54,6 +54,19 @@ export interface PrepareServerOptions {
    * project-local data (databases, logs, etc.). Defaults to `process.cwd()/.mpak`.
    */
   workspaceDir?: string;
+  /**
+   * Pre-resolved `user_config` values supplied by the host.
+   *
+   * When provided, these values are layered over the stored `config.json`
+   * values (caller wins, per field) before `user_config` validation runs.
+   * Use this to satisfy required fields without persisting them to disk —
+   * for example, when credentials live in a workspace-scoped secret store
+   * managed by the host runtime.
+   *
+   * Backward compatible: omitting this option (or passing an empty object)
+   * preserves the existing behavior of reading exclusively from stored config.
+   */
+  userConfig?: Record<string, string>;
 }
 
 /**
@@ -163,7 +176,7 @@ export class Mpak {
     }
 
     // Gather and validate user config
-    const userConfigValues = this.gatherUserConfig(name, manifest);
+    const userConfigValues = this.gatherUserConfig(name, manifest, options?.userConfig);
 
     // Build command/args/env
     const { command, args, env } = this.resolveCommand(manifest, cacheDir, userConfigValues);
@@ -268,10 +281,23 @@ export class Mpak {
   }
 
   /**
-   * Gather stored user config values and validate that all required fields are present.
-   * @throws If required config values are missing.
+   * Gather user config values and validate that all required fields are present.
+   *
+   * Resolution per field (first match wins):
+   *   1. `overrides[fieldName]` — caller-provided value (host runtime)
+   *   2. stored `config.json` value — from `MpakConfigManager`
+   *   3. `default` from the manifest
+   *   4. missing required → collected and thrown as `MpakConfigError`
+   *
+   * @param overrides Optional pre-resolved values that take precedence over stored config.
+   *                  An empty object is treated the same as omitting the argument.
+   * @throws {MpakConfigError} If required config values are missing from every tier.
    */
-  private gatherUserConfig(packageName: string, manifest: McpbManifest): Record<string, string> {
+  private gatherUserConfig(
+    packageName: string,
+    manifest: McpbManifest,
+    overrides?: Record<string, string>,
+  ): Record<string, string> {
     if (!manifest.user_config || Object.keys(manifest.user_config).length === 0) {
       return {};
     }
@@ -286,9 +312,12 @@ export class Mpak {
     }> = [];
 
     for (const [fieldName, fieldData] of Object.entries(manifest.user_config)) {
+      const overrideValue = overrides?.[fieldName];
       const storedValue = storedConfig[fieldName];
 
-      if (storedValue !== undefined) {
+      if (overrideValue !== undefined) {
+        result[fieldName] = overrideValue;
+      } else if (storedValue !== undefined) {
         result[fieldName] = storedValue;
       } else if (fieldData.default !== undefined && fieldData.default !== null) {
         result[fieldName] = String(fieldData.default);

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -591,6 +591,225 @@ describe('Mpak facade', () => {
   });
 
   // ===========================================================================
+  // prepareServer — userConfig override option
+  // ===========================================================================
+
+  describe('prepareServer (userConfig option)', () => {
+    const baseManifest: McpbManifest = {
+      manifest_version: '0.3',
+      name: '@scope/echo',
+      version: '1.0.0',
+      description: 'Echo server',
+      server: {
+        type: 'node',
+        entry_point: 'index.js',
+        mcp_config: {
+          command: 'node',
+          args: ['${__dirname}/index.js'],
+          env: {},
+        },
+      },
+    };
+
+    /**
+     * Build a manifest with the given user_config fields. Each field appears in
+     * mcp_config.env as `UPPERCASE_KEY: ${user_config.key}` so the resolved env
+     * directly reflects which source provided the value.
+     */
+    function manifestWithFields(fields: McpbManifest['user_config']): McpbManifest {
+      const envEntries: Record<string, string> = {};
+      for (const fieldName of Object.keys(fields ?? {})) {
+        envEntries[fieldName.toUpperCase()] = `\${user_config.${fieldName}}`;
+      }
+      return {
+        ...baseManifest,
+        user_config: fields,
+        server: {
+          ...baseManifest.server,
+          mcp_config: {
+            ...baseManifest.server.mcp_config,
+            env: envEntries,
+          },
+        },
+      };
+    }
+
+    function setupSdk(manifest: McpbManifest) {
+      const sdk = new Mpak({ mpakHome: testDir });
+      const cacheDir = join(testDir, 'cache', 'scope-echo');
+
+      vi.spyOn(sdk.bundleCache, 'loadBundle').mockResolvedValue({
+        cacheDir,
+        version: '1.0.0',
+        pulled: false,
+      });
+      vi.spyOn(sdk.bundleCache, 'getBundleManifest').mockReturnValue(manifest);
+
+      return { sdk, cacheDir };
+    }
+
+    it('satisfies a required user_config field from userConfig when nothing is stored', async () => {
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      // Nothing is stored in config.json — only the caller-provided value exists.
+      expect(sdk.configManager.getPackageConfig('@scope/echo')).toBeUndefined();
+
+      const result = await sdk.prepareServer(
+        { name: '@scope/echo' },
+        { userConfig: { api_key: 'sk-from-caller' } },
+      );
+
+      expect(result.env['API_KEY']).toBe('sk-from-caller');
+    });
+
+    it('caller userConfig takes precedence over stored config for the same field', async () => {
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      sdk.configManager.setPackageConfigValue('@scope/echo', 'api_key', 'sk-from-stored');
+
+      const result = await sdk.prepareServer(
+        { name: '@scope/echo' },
+        { userConfig: { api_key: 'sk-from-caller' } },
+      );
+
+      expect(result.env['API_KEY']).toBe('sk-from-caller');
+      // Stored value is NOT mutated — precedence is runtime only.
+      expect(sdk.configManager.getPackageConfig('@scope/echo')).toEqual({
+        api_key: 'sk-from-stored',
+      });
+    });
+
+    it('merges partial userConfig with stored config on a per-field basis', async () => {
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+        endpoint: { type: 'string', title: 'Endpoint', required: true },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      // Store both fields up front.
+      sdk.configManager.setPackageConfigValue('@scope/echo', 'api_key', 'sk-from-stored');
+      sdk.configManager.setPackageConfigValue(
+        '@scope/echo',
+        'endpoint',
+        'https://stored.example.com',
+      );
+
+      // Caller overrides only api_key; endpoint must still come from stored config.
+      const result = await sdk.prepareServer(
+        { name: '@scope/echo' },
+        { userConfig: { api_key: 'sk-from-caller' } },
+      );
+
+      expect(result.env['API_KEY']).toBe('sk-from-caller');
+      expect(result.env['ENDPOINT']).toBe('https://stored.example.com');
+    });
+
+    it('still throws MpakConfigError when userConfig lacks a required field', async () => {
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+        endpoint: { type: 'string', title: 'Endpoint', required: true },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      // Provide only one of two required fields.
+      await expect(
+        sdk.prepareServer({ name: '@scope/echo' }, { userConfig: { api_key: 'sk-from-caller' } }),
+      ).rejects.toThrow(MpakConfigError);
+
+      try {
+        await sdk.prepareServer(
+          { name: '@scope/echo' },
+          { userConfig: { api_key: 'sk-from-caller' } },
+        );
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(MpakConfigError);
+        const configErr = err as MpakConfigError;
+        // Only the unprovided field is reported missing.
+        expect(configErr.missingFields.map((f) => f.key)).toEqual(['endpoint']);
+      }
+    });
+
+    it('empty userConfig {} behaves the same as omitting the option', async () => {
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      sdk.configManager.setPackageConfigValue('@scope/echo', 'api_key', 'sk-from-stored');
+
+      const withOmitted = await sdk.prepareServer({ name: '@scope/echo' });
+      const withEmpty = await sdk.prepareServer({ name: '@scope/echo' }, { userConfig: {} });
+
+      expect(withOmitted.env['API_KEY']).toBe('sk-from-stored');
+      expect(withEmpty.env['API_KEY']).toBe('sk-from-stored');
+    });
+
+    it('empty userConfig {} still throws when stored config is missing required field', async () => {
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      await expect(sdk.prepareServer({ name: '@scope/echo' }, { userConfig: {} })).rejects.toThrow(
+        MpakConfigError,
+      );
+    });
+
+    it('userConfig does not override a manifest default when the caller does not provide the field', async () => {
+      const manifest = manifestWithFields({
+        port: { type: 'number', default: 3000 },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      // Caller provides a *different* field — the one with a default is untouched.
+      const result = await sdk.prepareServer(
+        { name: '@scope/echo' },
+        { userConfig: { unrelated: 'ignored' } },
+      );
+
+      expect(result.env['PORT']).toBe('3000');
+    });
+
+    it('userConfig overrides manifest default when caller provides the field', async () => {
+      const manifest = manifestWithFields({
+        port: { type: 'number', default: 3000 },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      const result = await sdk.prepareServer(
+        { name: '@scope/echo' },
+        { userConfig: { port: '8080' } },
+      );
+
+      expect(result.env['PORT']).toBe('8080');
+    });
+
+    it('omitting userConfig preserves the original stored-then-default resolution', async () => {
+      // Regression guard: ensure the new parameter does not change legacy behavior
+      // when callers do not opt in.
+      const manifest = manifestWithFields({
+        api_key: { type: 'string', title: 'API Key', required: true },
+        port: { type: 'number', default: 3000 },
+      });
+      const { sdk } = setupSdk(manifest);
+
+      sdk.configManager.setPackageConfigValue('@scope/echo', 'api_key', 'sk-stored');
+
+      const result = await sdk.prepareServer({ name: '@scope/echo' });
+
+      expect(result.env['API_KEY']).toBe('sk-stored');
+      expect(result.env['PORT']).toBe('3000');
+    });
+  });
+
+  // ===========================================================================
   // prepareServer — local bundles
   // ===========================================================================
 


### PR DESCRIPTION
## Summary

- Adds an optional `userConfig?: Record<string, string>` to `PrepareServerOptions` so host runtimes can provide pre-resolved `user_config` values.
- Values layer over stored `~/.mpak/config.json` config (caller wins per field) before validation runs. Required fields missing from every tier still throw `MpakConfigError`.
- Backward compatible: omitting `userConfig` (or passing `{}`) preserves existing behavior exactly.

## Why

NimbleBrain (and other host runtimes) need to resolve credentials from workspace-scoped stores that live outside `~/.mpak/`. Today, the only way to satisfy required `user_config` fields is to persist values to `config.json` via `MpakConfigManager` — which forces every host to write to a filesystem location it doesn't own, and breaks multi-tenant use cases where the same bundle needs different credentials per workspace.

Resolution order per field is now:
1. `options.userConfig[field]` — caller-provided (new)
2. stored `config.json` value
3. manifest `default`
4. missing required → `MpakConfigError`

## Test plan

- [x] 9 new tests in `tests/mpak.test.ts` covering override precedence, partial merges, empty override equivalence, missing-required error behavior, and regression on legacy code paths
- [x] All 200 existing SDK tests pass unchanged
- [x] `bunx tsc --noEmit` clean
- [x] No changes to `MpakConfigManager`, `resolveCommand`, or `substituteEnvVars`