### PR TITLE
feat(sdk): resolve user_config from reverse mcp_config.env lookup

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblebrain/mpak-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TypeScript SDK for mpak registry - MCPB bundles and Agent Skills",
   "author": "NimbleBrain Inc <engineering@mpak.dev>",
   "license": "Apache-2.0",

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -290,8 +290,17 @@ export class Mpak {
    * Resolution per field (first match wins):
    *   1. `overrides[fieldName]` — caller-provided value (host runtime)
    *   2. stored `config.json` value — from `MpakConfigManager`
-   *   3. `default` from the manifest
-   *   4. missing required → collected and thrown as `MpakConfigError`
+   *   3. host process env via manifest-declared alias — see {@link envAliasesForField}
+   *   4. `default` from the manifest
+   *   5. missing required → collected and thrown as `MpakConfigError`
+   *
+   * Tier 3 (env alias) reads the bundle's existing `server.mcp_config.env`
+   * declaration in reverse. A bundle that maps a field to a spawn env var,
+   * e.g. `"NEWSAPI_API_KEY": "${user_config.api_key}"`, implicitly says
+   * "the `api_key` field is about the NEWSAPI_API_KEY env var." At resolve
+   * time we honor that: if the host process has NEWSAPI_API_KEY set
+   * (non-empty), its value satisfies the field. No new schema field, no
+   * host-specific convention — the mapping is already declared.
    *
    * @param overrides Optional pre-resolved values that take precedence over stored config.
    *                  An empty object is treated the same as omitting the argument.
@@ -307,6 +316,7 @@ export class Mpak {
     }
 
     const storedConfig = this.configManager.getPackageConfig(packageName) ?? {};
+    const envAliases = buildEnvAliasMap(manifest);
     const result: Record<string, string> = {};
     const missingFields: Array<{
       key: string;
@@ -323,18 +333,33 @@ export class Mpak {
         result[fieldName] = overrideValue;
       } else if (storedValue !== undefined) {
         result[fieldName] = storedValue;
-      } else if (fieldData.default !== undefined && fieldData.default !== null) {
-        result[fieldName] = String(fieldData.default);
-      } else if (fieldData.required) {
-        const field: (typeof missingFields)[number] = {
-          key: fieldName,
-          title: fieldData.title ?? fieldName,
-          sensitive: fieldData.sensitive ?? false,
-        };
-        if (fieldData.description !== undefined) {
-          field.description = fieldData.description;
+      } else {
+        // Tier 3: env alias — bundle's mcp_config.env declared this field.
+        // Empty strings are treated as absent (accidentally-cleared export
+        // shouldn't mask a stored value or a default).
+        let envValue: string | undefined;
+        for (const envVar of envAliases.get(fieldName) ?? []) {
+          const v = process.env[envVar];
+          if (typeof v === 'string' && v.length > 0) {
+            envValue = v;
+            break;
+          }
         }
-        missingFields.push(field);
+        if (envValue !== undefined) {
+          result[fieldName] = envValue;
+        } else if (fieldData.default !== undefined && fieldData.default !== null) {
+          result[fieldName] = String(fieldData.default);
+        } else if (fieldData.required) {
+          const field: (typeof missingFields)[number] = {
+            key: fieldName,
+            title: fieldData.title ?? fieldName,
+            sensitive: fieldData.sensitive ?? false,
+          };
+          if (fieldData.description !== undefined) {
+            field.description = fieldData.description;
+          }
+          missingFields.push(field);
+        }
       }
     }
 
@@ -466,4 +491,40 @@ export class Mpak {
     }
     return 'python';
   }
+}
+
+/**
+ * Build a reverse map from `user_config` field name → host env var aliases,
+ * based on the bundle's existing `server.mcp_config.env` declaration.
+ *
+ * A declaration like `"NEWSAPI_API_KEY": "${user_config.api_key}"` says
+ * "when the api_key field is resolved, put it in NEWSAPI_API_KEY for the
+ * spawned process." Read in reverse: the host's NEWSAPI_API_KEY env var
+ * can satisfy the api_key field.
+ *
+ * Only whole-value single-substitution templates participate. A template
+ * with literal text (`"PREFIX_${user_config.x}_SUFFIX"`) or multiple
+ * substitutions (`"${user_config.a}-${user_config.b}"`) has no clean
+ * inverse — the env var would have to be unpicked back into constituent
+ * parts. Those are skipped; the field falls through to default/prompt.
+ *
+ * Multiple env vars may map to the same field — the field's alias list
+ * preserves declaration order so the first non-empty match wins.
+ */
+function buildEnvAliasMap(manifest: McpbManifest): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  const entries = manifest.server?.mcp_config?.env;
+  if (!entries) return map;
+
+  const wholeSubstitution = /^\$\{user_config\.([A-Za-z_][A-Za-z0-9_]*)\}$/;
+  for (const [envVar, template] of Object.entries(entries)) {
+    if (typeof template !== 'string') continue;
+    const match = wholeSubstitution.exec(template);
+    if (!match) continue;
+    const fieldName = match[1]!;
+    const existing = map.get(fieldName);
+    if (existing) existing.push(envVar);
+    else map.set(fieldName, [envVar]);
+  }
+  return map;
 }

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -987,4 +987,227 @@ describe('Mpak facade', () => {
       await expect(sdk.prepareServer({ local: mcpbPath })).rejects.toThrow(MpakConfigError);
     });
   });
+
+  // ===========================================================================
+  // prepareServer — env alias tier (reverse mcp_config.env lookup)
+  // ===========================================================================
+  //
+  // A bundle that maps a user_config field to a spawn env var — e.g.
+  // `"NEWSAPI_API_KEY": "${user_config.api_key}"` — implicitly declares
+  // "the api_key field is about NEWSAPI_API_KEY." The SDK reads this
+  // declaration in reverse at resolve time: if the host process has
+  // NEWSAPI_API_KEY set non-empty, it satisfies the field. No new schema
+  // field, no host convention — the bundle's existing canonical declaration
+  // is the single source of truth.
+
+  describe('prepareServer (env alias tier)', () => {
+    const baseManifest: McpbManifest = {
+      manifest_version: '0.3',
+      name: '@scope/newsapi',
+      version: '1.0.0',
+      description: 'News API client',
+      server: {
+        type: 'node',
+        entry_point: 'index.js',
+        mcp_config: {
+          command: 'node',
+          args: ['${__dirname}/index.js'],
+          env: {},
+        },
+      },
+    };
+
+    /** Build a manifest with declared mcp_config.env mappings and user_config fields. */
+    function manifestWith(
+      envMap: Record<string, string>,
+      fields: McpbManifest['user_config'],
+    ): McpbManifest {
+      return {
+        ...baseManifest,
+        user_config: fields,
+        server: {
+          ...baseManifest.server,
+          mcp_config: { ...baseManifest.server.mcp_config, env: envMap },
+        },
+      };
+    }
+
+    function setupSdk(manifest: McpbManifest) {
+      const sdk = new Mpak({ mpakHome: testDir });
+      const cacheDir = join(testDir, 'cache', 'scope-newsapi');
+      vi.spyOn(sdk.bundleCache, 'loadBundle').mockResolvedValue({
+        cacheDir,
+        version: '1.0.0',
+        pulled: false,
+      });
+      vi.spyOn(sdk.bundleCache, 'getBundleManifest').mockReturnValue(manifest);
+      return sdk;
+    }
+
+    /** Snapshot and restore a named env var across a test body. */
+    async function withEnv(name: string, value: string | undefined, fn: () => Promise<void>) {
+      const prev = process.env[name];
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+      try {
+        await fn();
+      } finally {
+        if (prev === undefined) delete process.env[name];
+        else process.env[name] = prev;
+      }
+    }
+
+    it('a declared single-substitution env var satisfies a required field', async () => {
+      const manifest = manifestWith(
+        { NEWSAPI_API_KEY: '${user_config.api_key}' },
+        { api_key: { type: 'string', title: 'API Key', required: true } },
+      );
+      const sdk = setupSdk(manifest);
+
+      await withEnv('NEWSAPI_API_KEY', 'sk-from-env', async () => {
+        const result = await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect(result.env['NEWSAPI_API_KEY']).toBe('sk-from-env');
+      });
+    });
+
+    it('precedence: overrides beats stored beats env beats default', async () => {
+      const manifest = manifestWith(
+        { NEWSAPI_API_KEY: '${user_config.api_key}' },
+        { api_key: { type: 'string', title: 'API Key', default: 'default-val' } },
+      );
+      const sdk = setupSdk(manifest);
+      sdk.configManager.setPackageConfigValue('@scope/newsapi', 'api_key', 'from-stored');
+
+      await withEnv('NEWSAPI_API_KEY', 'from-env', async () => {
+        // Override wins over everything else.
+        const withOverride = await sdk.prepareServer(
+          { name: '@scope/newsapi' },
+          { userConfig: { api_key: 'from-override' } },
+        );
+        expect(withOverride.env['NEWSAPI_API_KEY']).toBe('from-override');
+
+        // Stored wins over env and default.
+        const withStored = await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect(withStored.env['NEWSAPI_API_KEY']).toBe('from-stored');
+      });
+
+      // Env wins over default when no stored value.
+      sdk.configManager.clearPackageConfig('@scope/newsapi');
+      await withEnv('NEWSAPI_API_KEY', 'from-env', async () => {
+        const withEnvOnly = await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect(withEnvOnly.env['NEWSAPI_API_KEY']).toBe('from-env');
+      });
+
+      // Default wins when env is unset.
+      await withEnv('NEWSAPI_API_KEY', undefined, async () => {
+        const withDefault = await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect(withDefault.env['NEWSAPI_API_KEY']).toBe('default-val');
+      });
+    });
+
+    it('empty env var string is treated as absent', async () => {
+      const manifest = manifestWith(
+        { NEWSAPI_API_KEY: '${user_config.api_key}' },
+        { api_key: { type: 'string', title: 'API Key', required: true } },
+      );
+      const sdk = setupSdk(manifest);
+
+      await withEnv('NEWSAPI_API_KEY', '', async () => {
+        // Empty export shouldn't mask the missing-required error.
+        await expect(sdk.prepareServer({ name: '@scope/newsapi' })).rejects.toThrow(
+          MpakConfigError,
+        );
+      });
+    });
+
+    it('multiple env vars mapped to the same field — first non-empty wins, declaration order', async () => {
+      // A bundle could declare both a canonical and an alias name for the
+      // same field. The SDK honors declaration order.
+      const manifest = manifestWith(
+        {
+          ANTHROPIC_API_KEY: '${user_config.key}',
+          CLAUDE_API_KEY: '${user_config.key}',
+        },
+        { key: { type: 'string', title: 'Key', required: true } },
+      );
+      const sdk = setupSdk(manifest);
+
+      await withEnv('CLAUDE_API_KEY', 'from-claude', async () => {
+        await withEnv('ANTHROPIC_API_KEY', undefined, async () => {
+          // Only the alias is set — alias wins because canonical is empty.
+          const result = await sdk.prepareServer({ name: '@scope/newsapi' });
+          expect(result.env['ANTHROPIC_API_KEY']).toBe('from-claude');
+          expect(result.env['CLAUDE_API_KEY']).toBe('from-claude');
+        });
+
+        await withEnv('ANTHROPIC_API_KEY', 'from-anthropic', async () => {
+          // Both set — canonical (declared first) wins.
+          const result = await sdk.prepareServer({ name: '@scope/newsapi' });
+          expect(result.env['ANTHROPIC_API_KEY']).toBe('from-anthropic');
+        });
+      });
+    });
+
+    it('literal values in mcp_config.env are ignored (no substitution to reverse)', async () => {
+      const manifest = manifestWith(
+        {
+          LOG_LEVEL: 'info',
+          NEWSAPI_API_KEY: '${user_config.api_key}',
+        },
+        { api_key: { type: 'string', title: 'API Key', required: true } },
+      );
+      const sdk = setupSdk(manifest);
+
+      // A host env var matching a literal entry's KEY must not satisfy a
+      // user_config field (there's no `${user_config.*}` to reverse).
+      await withEnv('LOG_LEVEL', 'debug', async () => {
+        await expect(sdk.prepareServer({ name: '@scope/newsapi' })).rejects.toThrow(
+          MpakConfigError,
+        );
+      });
+    });
+
+    it('template with literal text or multiple substitutions is skipped (no clean inverse)', async () => {
+      const manifest = manifestWith(
+        {
+          // Literal prefix + substitution — cannot be reversed unambiguously.
+          PREFIXED: 'prefix-${user_config.api_key}',
+          // Multiple substitutions — cannot be split back into components.
+          COMPOSITE: '${user_config.a}-${user_config.b}',
+        },
+        {
+          api_key: { type: 'string', title: 'API Key', required: true },
+          a: { type: 'string', title: 'A', required: true },
+          b: { type: 'string', title: 'B', required: true },
+        },
+      );
+      const sdk = setupSdk(manifest);
+
+      // Setting PREFIXED doesn't satisfy api_key — the template isn't a
+      // whole-value substitution.
+      await withEnv('PREFIXED', 'prefix-sk-xxx', async () => {
+        await withEnv('COMPOSITE', 'a-b', async () => {
+          await expect(sdk.prepareServer({ name: '@scope/newsapi' })).rejects.toThrow(
+            MpakConfigError,
+          );
+        });
+      });
+    });
+
+    it('bundle with no mcp_config.env declarations — env tier is empty, falls back as before', async () => {
+      const manifest = manifestWith(
+        {}, // no declared env mappings
+        { api_key: { type: 'string', title: 'API Key', required: true } },
+      );
+      const sdk = setupSdk(manifest);
+
+      // Without a declared mapping, no host env var can satisfy the field.
+      // Set something obvious to confirm it's ignored.
+      await withEnv('API_KEY', 'from-env', async () => {
+        await expect(sdk.prepareServer({ name: '@scope/newsapi' })).rejects.toThrow(
+          MpakConfigError,
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a new resolution tier to the SDK's \`gatherUserConfig\`: the bundle's existing \`server.mcp_config.env\` declaration is read in reverse at resolve time. If a bundle maps a field via \`\"NEWSAPI_API_KEY\": \"\${user_config.api_key}\"\`, then a host \`process.env.NEWSAPI_API_KEY\` satisfies that field.

No new schema field. No new convention. No \`_meta\` extension. The bundle's canonical MCPB declaration is the single source of truth — we just use it both ways.

## Why

Host runtimes that wrap mpak have been inventing their own env-var naming schemes to let users satisfy \`user_config\` fields from the host's process env. NimbleBrain shipped \`NB_CONFIG_{SCOPE}_{NAME}_{FIELD}\` last week — ugly, forces users to rename exports away from industry defaults (\`ANTHROPIC_API_KEY\` becomes \`NB_CONFIG_NIMBLEBRAIN_WEBFETCH_ANTHROPIC_API_KEY\`), and carries a special-case \`inc\`-stripping rule for one specific GitHub org.

Pushing this into the SDK, using the mapping the bundle already declares, removes the need for any host-specific convention. Every mpak host benefits uniformly. Bundles wrapping de-facto-standard services (Anthropic, OpenAI, GitHub) work with their canonical env vars by default.

## Resolution order

Per user_config field, first non-empty wins:

1. \`options.userConfig[field]\` — caller override (unchanged)
2. stored \`config.json\` value — from \`MpakConfigManager\` (unchanged)
3. **env alias via \`mcp_config.env\` — new**
4. manifest \`default\` — unchanged
5. missing required → \`MpakConfigError\` — unchanged

## Semantics

- Only **whole-value single-substitution** templates participate. \`\"X\": \"\${user_config.a}\"\` is reversible. \`\"X\": \"prefix-\${user_config.a}\"\` or \`\"X\": \"\${user_config.a}-\${user_config.b}\"\` are not — they're skipped and the field falls through.
- **Empty strings are treated as absent** to prevent an accidentally-cleared export from masking a stored value or default.
- **Multiple env vars mapped to the same field** iterate in declaration order — first non-empty wins. This lets bundles declare canonical names before aliases (\`ANTHROPIC_API_KEY\` then \`CLAUDE_API_KEY\`).
- **Bundles with no \`mcp_config.env\` declarations** have an empty env tier — fallthrough is unchanged.

## Test plan

- [x] 7 new tests in \`tests/mpak.test.ts\` covering: single mapping, full precedence ordering across all five tiers, empty-env-string treated as absent, multi-alias declaration order (canonical wins when both set), literal values ignored (no substitution to reverse), composite templates skipped, and missing-mapping fallthrough
- [x] All 200 existing SDK tests pass unchanged
- [x] \`pnpm --filter @nimblebrain/mpak-sdk typecheck\` clean
- [x] \`pnpm --filter @nimblebrain/mpak-sdk lint\` clean
- [x] \`prettier --check\` clean on new code

## Follow-ups

After this publishes as \`0.4.0\`, NimbleBrain will drop its \`NB_CONFIG_*\` convention (\`envVarName\`, \`normalizeScope\`, and the process-env tier in \`resolveUserConfig\`) and rely on this SDK behavior instead. Net \~40 lines deleted from NimbleBrain.