### PR TITLE
fix(sdk): QA fixups on env-alias reverse lookup

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblebrain/mpak-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeScript SDK for mpak registry - MCPB bundles and Agent Skills",
   "author": "NimbleBrain Inc <engineering@mpak.dev>",
   "license": "Apache-2.0",

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -465,6 +465,16 @@ export class Mpak {
 
   /**
    * Substitute `${user_config.*}` placeholders in env vars.
+   *
+   * When a bundle maps the same field to multiple env vars, e.g.
+   *   `{ "ANTHROPIC_API_KEY": "${user_config.key}",
+   *      "CLAUDE_API_KEY":    "${user_config.key}" }`
+   * every mapped var receives the resolved value on spawn, even if the
+   * env-alias tier in `gatherUserConfig` only matched one of them in the
+   * host process. That's intentional: once a field is resolved, all of
+   * the bundle's declared destinations for that field get populated —
+   * it's the bundle author's declaration of "these names mean this
+   * field to me." Tests pin this behavior down in mpak.test.ts.
    */
   private static substituteEnvVars(
     env: Record<string, string> | undefined,
@@ -473,6 +483,11 @@ export class Mpak {
     if (!env) return {};
     const result: Record<string, string> = {};
     for (const [key, value] of Object.entries(env)) {
+      // Zod's `z.record(z.string(), z.string())` rejects non-strings at
+      // parse time, but guard here anyway so a malformed manifest that
+      // bypasses parse (tests, hand-built objects) can't take down the
+      // resolver. Kept in sync with `buildEnvAliasMap`'s guard.
+      if (typeof value !== 'string') continue;
       result[key] = value.replace(
         /\$\{user_config\.([^}]+)\}/g,
         (match, configKey: string) => userConfigValues[configKey] ?? match,
@@ -516,7 +531,12 @@ function buildEnvAliasMap(manifest: McpbManifest): Map<string, string[]> {
   const entries = manifest.server?.mcp_config?.env;
   if (!entries) return map;
 
-  const wholeSubstitution = /^\$\{user_config\.([A-Za-z_][A-Za-z0-9_]*)\}$/;
+  // Keep this character class aligned with the forward substitution in
+  // `resolveCommand` (`[^}]+`). Any field name that forward-substitutes
+  // cleanly must also reverse-resolve, otherwise a bundle author using
+  // e.g. `${user_config.api-key}` sees their spawn env populate at
+  // runtime but the env-alias tier silently misses at resolve time.
+  const wholeSubstitution = /^\$\{user_config\.([^}]+)\}$/;
   for (const [envVar, template] of Object.entries(entries)) {
     if (typeof template !== 'string') continue;
     const match = wholeSubstitution.exec(template);

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -1209,5 +1209,59 @@ describe('Mpak facade', () => {
         );
       });
     });
+
+    it('hyphenated field name in mcp_config.env round-trips both directions', async () => {
+      // The forward substitution accepts any char except `}`, so a bundle
+      // is free to use hyphens (`${user_config.api-key}`). The reverse
+      // lookup must accept the same alphabet — otherwise a host export
+      // satisfies the forward path at spawn but not the resolve tier.
+      // QA-flagged asymmetry; pinned here so it can't regress.
+      const manifest = manifestWith(
+        { NEWSAPI_API_KEY: '${user_config.api-key}' },
+        { 'api-key': { type: 'string', title: 'API Key', required: true } },
+      );
+      const sdk = setupSdk(manifest);
+
+      await withEnv('NEWSAPI_API_KEY', 'sk-from-env', async () => {
+        const result = await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect(result.env['NEWSAPI_API_KEY']).toBe('sk-from-env');
+      });
+    });
+
+    it('non-string values in mcp_config.env are skipped defensively', async () => {
+      // Zod's `z.record(z.string(), z.string())` rejects non-strings at
+      // parse time in production, so this path is guard-rail only. The
+      // test uses a hand-built manifest object (bypassing parse) to pin
+      // the guard in place — if the schema ever loosens, this fallback
+      // prevents a runtime crash in `resolveCommand`.
+      const manifest = {
+        ...baseManifest,
+        user_config: {
+          api_key: { type: 'string' as const, title: 'API Key', required: true },
+        },
+        server: {
+          ...baseManifest.server,
+          mcp_config: {
+            ...baseManifest.server.mcp_config,
+            env: {
+              // Intentionally malformed to exercise the non-string guard.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              NUMBER_VAL: 42 as any,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              NULL_VAL: null as any,
+              NEWSAPI_API_KEY: '${user_config.api_key}',
+            },
+          },
+        },
+      } as McpbManifest;
+      const sdk = setupSdk(manifest);
+
+      await withEnv('NEWSAPI_API_KEY', 'sk-survives', async () => {
+        // Valid string entry still reverses; malformed entries are skipped
+        // without taking down the resolver.
+        const result = await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect(result.env['NEWSAPI_API_KEY']).toBe('sk-survives');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Three fixups on the env-alias feature shipped in #82. One is a real bug, two are hygiene.

### 1. Regex asymmetry (bug fix)

Forward substitution in \`resolveCommand\` uses \`[^}]+\` for the user_config field name — anything except a closing brace. The reverse lookup in \`buildEnvAliasMap\` used stricter \`[A-Za-z_][A-Za-z0-9_]*\`. So a bundle with a hyphenated field name like \`\${user_config.api-key}\` would:

- ✅ Forward-substitute at spawn time (SDK happily replaces it)
- ❌ Silently skip the reverse tier at resolve time (regex rejects the name)

That asymmetry is a footgun. Aligned both to \`[^}]+\`.

### 2. Non-obvious multi-alias semantics (docs)

When a bundle maps the same field to multiple env vars, all of them get populated at spawn even if only one was set in the host process. This is intentional but surprising. Added a JSDoc block to \`substituteEnvVars\` documenting the contract.

### 3. Non-string \`mcp_config.env\` value guard (test + alignment)

Writing the test for the existing \`typeof template !== 'string'\` guard in \`buildEnvAliasMap\` surfaced a latent bug: \`substituteEnvVars\` had no matching guard, so a hand-built manifest with non-string values would crash with \`value.replace is not a function\`. Added the same guard there. Zod catches this in production; the guard is defense for tests and any path that bypasses parse.

## Test plan

- [x] 2 new tests: hyphenated field name round-trip, non-string values skipped
- [x] 207 existing tests still pass (209 total)
- [x] typecheck, lint, prettier clean

## Version

Bump \`0.4.0\` → \`0.4.1\` (patch — bugfix + coverage + docs).