### PR TITLE
feat(sdk)!: attach envAliases to MpakConfigError.missingFields

### DIFF
--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblebrain/mpak-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "TypeScript SDK for mpak registry - MCPB bundles and Agent Skills",
   "author": "NimbleBrain Inc <engineering@mpak.dev>",
   "license": "Apache-2.0",

--- a/packages/sdk-typescript/src/errors.ts
+++ b/packages/sdk-typescript/src/errors.ts
@@ -113,11 +113,23 @@ export class MpakInvalidBundleError extends MpakError {
 export class MpakConfigError extends MpakError {
   constructor(
     public readonly packageName: string,
+    /**
+     * The fields that could not be satisfied by any of the SDK's resolution
+     * tiers (override, stored config, env alias, manifest default).
+     *
+     * `envAliases` lists the host env var names the bundle declared as
+     * satisfying this field in its `server.mcp_config.env`. Empty when the
+     * bundle has no `${user_config.<field>}` mapping. Always present —
+     * consumers never need to re-derive this from the manifest. A friendly
+     * error-translator can render a `export ANTHROPIC_API_KEY=...` hint
+     * directly from the error without reaching back into the manifest.
+     */
     public readonly missingFields: Array<{
       key: string;
       title: string;
       description?: string;
       sensitive: boolean;
+      envAliases: string[];
     }>,
   ) {
     const fieldNames = missingFields.map((f) => f.title).join(', ');

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -323,6 +323,7 @@ export class Mpak {
       title: string;
       description?: string;
       sensitive: boolean;
+      envAliases: string[];
     }> = [];
 
     for (const [fieldName, fieldData] of Object.entries(manifest.user_config)) {
@@ -337,8 +338,9 @@ export class Mpak {
         // Tier 3: env alias — bundle's mcp_config.env declared this field.
         // Empty strings are treated as absent (accidentally-cleared export
         // shouldn't mask a stored value or a default).
+        const aliasesForField = envAliases.get(fieldName) ?? [];
         let envValue: string | undefined;
-        for (const envVar of envAliases.get(fieldName) ?? []) {
+        for (const envVar of aliasesForField) {
           const v = process.env[envVar];
           if (typeof v === 'string' && v.length > 0) {
             envValue = v;
@@ -350,10 +352,14 @@ export class Mpak {
         } else if (fieldData.default !== undefined && fieldData.default !== null) {
           result[fieldName] = String(fieldData.default);
         } else if (fieldData.required) {
+          // Attach the same alias list the tier-3 lookup just tried, so
+          // error-translators can point users at `export ANTHROPIC_API_KEY=…`
+          // without re-deriving the mapping from the manifest.
           const field: (typeof missingFields)[number] = {
             key: fieldName,
             title: fieldData.title ?? fieldName,
             sensitive: fieldData.sensitive ?? false,
+            envAliases: aliasesForField,
           };
           if (fieldData.description !== undefined) {
             field.description = fieldData.description;

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -501,9 +501,12 @@ describe('Mpak facade', () => {
         expect(err).toBeInstanceOf(MpakConfigError);
         const configErr = err as MpakConfigError;
         expect(configErr.packageName).toBe('@scope/echo');
+        // envAliases is always present — empty array when the bundle
+        // declared no `${user_config.<field>}` mapping (nodeManifest
+        // above has `mcp_config.env: {}`).
         expect(configErr.missingFields).toEqual([
-          { key: 'api_key', title: 'API Key', sensitive: true },
-          { key: 'endpoint', title: 'Endpoint URL', sensitive: false },
+          { key: 'api_key', title: 'API Key', sensitive: true, envAliases: [] },
+          { key: 'endpoint', title: 'Endpoint URL', sensitive: false, envAliases: [] },
         ]);
       }
     });
@@ -536,12 +539,19 @@ describe('Mpak facade', () => {
         expect(err).toBeInstanceOf(MpakConfigError);
         const configErr = err as MpakConfigError;
         expect(configErr.missingFields).toEqual([
-          { key: 'api_key', title: 'API Key', description: 'Your OpenAI API key', sensitive: true },
+          {
+            key: 'api_key',
+            title: 'API Key',
+            description: 'Your OpenAI API key',
+            sensitive: true,
+            envAliases: [],
+          },
           {
             key: 'endpoint',
             title: 'Endpoint URL',
             description: 'The API base URL',
             sensitive: false,
+            envAliases: [],
           },
         ]);
       }
@@ -1262,6 +1272,78 @@ describe('Mpak facade', () => {
         const result = await sdk.prepareServer({ name: '@scope/newsapi' });
         expect(result.env['NEWSAPI_API_KEY']).toBe('sk-survives');
       });
+    });
+
+    it('MpakConfigError.missingFields[i].envAliases lists the bundle-declared env var names', async () => {
+      // The error carries everything a friendly translator needs to render
+      // `export ANTHROPIC_API_KEY=<value>` hints — no consumer should have
+      // to re-derive the mapping from the manifest. Canonical first, alias
+      // second; declaration order preserved.
+      const manifest = manifestWith(
+        {
+          ANTHROPIC_API_KEY: '${user_config.api_key}',
+          CLAUDE_API_KEY: '${user_config.api_key}',
+          OTHER_MAPPING: '${user_config.other_field}',
+          LITERAL: 'not-a-substitution',
+          PARTIAL: 'prefix-${user_config.api_key}',
+        },
+        {
+          api_key: {
+            type: 'string',
+            title: 'API Key',
+            description: 'Anthropic API key',
+            required: true,
+          },
+          other_field: {
+            type: 'string',
+            title: 'Other',
+            description: 'Another required field',
+            required: true,
+          },
+        },
+      );
+      const sdk = setupSdk(manifest);
+
+      // Nothing set anywhere — both fields land in missingFields.
+      try {
+        await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(MpakConfigError);
+        const configErr = err as MpakConfigError;
+
+        const apiKeyField = configErr.missingFields.find((f) => f.key === 'api_key');
+        expect(apiKeyField?.envAliases).toEqual(['ANTHROPIC_API_KEY', 'CLAUDE_API_KEY']);
+
+        const otherField = configErr.missingFields.find((f) => f.key === 'other_field');
+        expect(otherField?.envAliases).toEqual(['OTHER_MAPPING']);
+      }
+    });
+
+    it('MpakConfigError.missingFields[i].envAliases is empty when the bundle declared no mapping', async () => {
+      const manifest = manifestWith(
+        {}, // no env mappings at all
+        {
+          api_key: {
+            type: 'string',
+            title: 'API Key',
+            description: 'API key for the service',
+            required: true,
+          },
+        },
+      );
+      const sdk = setupSdk(manifest);
+
+      try {
+        await sdk.prepareServer({ name: '@scope/newsapi' });
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(MpakConfigError);
+        const configErr = err as MpakConfigError;
+        // Required, always present — consumers can iterate without a
+        // nullish check.
+        expect(configErr.missingFields[0]?.envAliases).toEqual([]);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

\`MpakConfigError.missingFields[i]\` gains a required \`envAliases: string[]\` field listing the host env var names the bundle declared as satisfying that field in its \`server.mcp_config.env\`. Consumers rendering friendly \"export NEWSAPI_API_KEY=...\" hints no longer re-derive the mapping from the manifest.

## Before vs after

**Before** — consumers duplicate the SDK's \`buildEnvAliasMap\` regex + whole-value-substitution rule to compute aliases externally. NimbleBrain's \`friendlyMpakConfigError\` carried a \"keep in sync with SDK\" comment.

**After** — the error is self-describing. Consumers read \`field.envAliases\` directly:

\`\`\`ts
catch (err) {
  if (err instanceof MpakConfigError) {
    for (const f of err.missingFields) {
      // ...one export suggestion per declared alias...
      for (const envVar of f.envAliases) console.log(\`export \${envVar}=<value>\`);
    }
  }
}
\`\`\`

## Why required, not optional

\`envAliases: []\` is a meaningful state — \"this field has no env alias declared.\" \`undefined\` would encode the same state redundantly, forcing consumers to write \`?? []\` forever to sidestep a lie in the type system. See discussion in the thread that produced this PR; the one-time test-constructor update cost is worth the honest type.

## Breaking change

\`MpakConfigError\` constructors must now pass \`envAliases\` on each missingField. Production callers are readers, not constructors — only affects tests that build error instances directly.

Per 0.x semver convention, bump to \`0.5.0\`.

## Migration

For TS test code that constructs MpakConfigError:

\`\`\`diff
  new MpakConfigError(\"@scope/bundle\", [
-   { key: \"api_key\", title: \"API Key\", sensitive: true },
+   { key: \"api_key\", title: \"API Key\", sensitive: true, envAliases: [] },
  ])
\`\`\`

NimbleBrain's consumer will be updated in a follow-up PR on the nimblebrain repo.

## Test plan

- [x] 2 new tests pin the new shape — one with multi-alias declaration-order preservation, one with the empty-array fallback
- [x] Pre-existing error-shape tests updated to expect \`envAliases: []\`
- [x] All 211 SDK tests pass
- [x] typecheck, lint, prettier clean
- [x] Test fixtures added by this PR are canonical-MCPB-conformant (include \`title\` + \`description\`)

## Out of scope

Pre-existing mpak-schemas drift from canonical MCPB v0.4 (optional \`title\`/\`description\`, missing \`directory\`/\`file\` types, etc.) is tracked in #84.