### PR TITLE
fix(sdk): stream extractZip with yauzl — fixes ENOBUFS on large bundles

### DIFF
--- a/packages/sdk-typescript/README.md
+++ b/packages/sdk-typescript/README.md
@@ -286,12 +286,15 @@ Properties: `config` (ConfigManager), `client` (MpakClient), `cache` (BundleCach
 | `getPackageCachePath(packageName)` | Get the cache directory path for a package |
 | `checkForUpdateAsync(packageName)` | Fire-and-forget update check (logs result) |
 
-#### Static Methods
+#### Utility Exports
 
-| Method | Description |
+Standalone functions exported from the package (not methods on any class):
+
+| Export | Description |
 |---|---|
-| `BundleCache.extractZip(zipPath, destDir)` | Extract a ZIP with zip-bomb protection |
-| `BundleCache.isSemverEqual(a, b)` | Compare semver strings (ignores `v` prefix) |
+| `extractZip(zipPath, destDir, options?)` | Async. Stream-extract a ZIP with zip-bomb, path-traversal, and symlink protection. Pass `{ maxUncompressedSize }` to override the default cap. |
+| `MAX_UNCOMPRESSED_SIZE` | Default uncompressed-size cap applied by `extractZip` (2 GB). |
+| `isSemverEqual(a, b)` | Compare semver strings (ignores `v` prefix) |
 
 ### ConfigManager (`mpak.config`)
 

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -62,10 +62,12 @@
   },
   "dependencies": {
     "@nimblebrain/mpak-schemas": "workspace:*",
+    "yauzl": "^3.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/yauzl": "^2.10.3",
     "jszip": "^3.10.1",
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",

--- a/packages/sdk-typescript/src/cache.ts
+++ b/packages/sdk-typescript/src/cache.ts
@@ -15,6 +15,11 @@ import { extractZip, isSemverEqual, readJsonFromFile, UPDATE_CHECK_TTL_MS } from
 
 export interface MpakBundleCacheOptions {
   mpakHome?: string;
+  /**
+   * Maximum allowed uncompressed size (bytes) for any bundle this cache
+   * extracts. Defaults to {@link MAX_UNCOMPRESSED_SIZE}.
+   */
+  maxUncompressedSize?: number;
 }
 
 /**
@@ -41,12 +46,14 @@ export interface MpakBundleCacheOptions {
  */
 export class MpakBundleCache {
   public readonly cacheHome: string;
+  public readonly maxUncompressedSize: number | undefined;
   private readonly mpakClient: MpakClient;
 
   constructor(client: MpakClient, options?: MpakBundleCacheOptions) {
     this.mpakClient = client;
 
     this.cacheHome = join(options?.mpakHome ?? join(homedir(), '.mpak'), 'cache');
+    this.maxUncompressedSize = options?.maxUncompressedSize;
   }
 
   /**
@@ -293,7 +300,7 @@ export class MpakBundleCache {
         rmSync(cacheDir, { recursive: true, force: true });
       }
 
-      extractZip(tempPath, cacheDir);
+      await extractZip(tempPath, cacheDir, this.extractOptions());
 
       // Write metadata
       this.writeCacheMetadata(name, {
@@ -304,5 +311,12 @@ export class MpakBundleCache {
     } finally {
       rmSync(tempPath, { force: true });
     }
+  }
+
+  /** Options threaded into every `extractZip` call. */
+  extractOptions(): { maxUncompressedSize?: number } {
+    return this.maxUncompressedSize !== undefined
+      ? { maxUncompressedSize: this.maxUncompressedSize }
+      : {};
   }
 }

--- a/packages/sdk-typescript/src/helpers.ts
+++ b/packages/sdk-typescript/src/helpers.ts
@@ -1,19 +1,42 @@
-import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import {
+  chmodSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { Transform, type Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import yauzl, { type Entry, type ZipFile } from 'yauzl';
 import type { z } from 'zod';
 import { MpakCacheCorruptedError, MpakError } from './errors.js';
 
 /**
- * Maximum allowed uncompressed size for a bundle (500MB).
+ * Default maximum allowed uncompressed size for a bundle (2GB).
+ *
+ * Override per-consumer via `MpakBundleCache` / `Mpak` options
+ * (`maxUncompressedSize`), or per-call via the `extractZip` options.
  */
-export const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024;
+export const MAX_UNCOMPRESSED_SIZE = 2 * 1024 * 1024 * 1024;
 
 /**
  * TTL for update checks — skip if last check was within this window (1 hour).
  */
 export const UPDATE_CHECK_TTL_MS = 60 * 60 * 1000;
+
+/** Options for {@link extractZip}. */
+export interface ExtractZipOptions {
+  /**
+   * Maximum total uncompressed size in bytes. Defaults to
+   * {@link MAX_UNCOMPRESSED_SIZE}. Enforced against both the declared
+   * central-directory sizes and the actual bytes written during extraction
+   * (the latter defeats zip bombs that lie about declared sizes).
+   */
+  maxUncompressedSize?: number;
+}
 
 /**
  * Compare two semver strings for equality, ignoring leading 'v' prefix.
@@ -23,46 +46,201 @@ export function isSemverEqual(a: string, b: string): boolean {
 }
 
 /**
- * Check uncompressed size and extract a ZIP file to a directory.
- * Rejects bundles exceeding {@link MAX_UNCOMPRESSED_SIZE} (zip-bomb protection).
+ * Extract a ZIP file to a directory, streaming entries to disk.
  *
- * Requires the `unzip` system command to be available on PATH.
+ * Guarantees:
+ * - **Zip-bomb protection:** the declared total uncompressed size (from the
+ *   central directory) is checked before any files are written; during
+ *   extraction, per-entry and cumulative byte counts are tracked and
+ *   extraction aborts if either would exceed limits.
+ * - **Path-traversal safe:** entry paths are resolved against `destDir` and
+ *   any entry that escapes the destination is rejected.
+ * - **Symlinks rejected:** bundles should not contain symlinks; their
+ *   presence fails extraction.
+ * - **Unix mode bits preserved** for entries that declare them (matches the
+ *   behavior of the prior `unzip` shell-out).
  *
- * @throws If uncompressed size exceeds the limit or extraction fails.
+ * Uses a pure-JS zip library — no dependency on the `unzip` binary.
+ *
+ * @throws {MpakCacheCorruptedError} for any format, size, or safety violation.
  */
-export function extractZip(zipPath: string, destDir: string): void {
-  // Check uncompressed size before extraction
+export async function extractZip(
+  zipPath: string,
+  destDir: string,
+  options: ExtractZipOptions = {},
+): Promise<void> {
+  const maxSize = options.maxUncompressedSize ?? MAX_UNCOMPRESSED_SIZE;
+
+  let zipfile: ZipFile;
   try {
-    const listOutput = execFileSync('unzip', ['-l', zipPath], {
-      stdio: 'pipe',
-      encoding: 'utf8',
-    });
-    const totalMatch = listOutput.match(/^\s*(\d+)\s+\d+\s+files?$/m);
-    if (totalMatch) {
-      const totalSize = parseInt(totalMatch[1] ?? '0', 10);
-      if (totalSize > MAX_UNCOMPRESSED_SIZE) {
-        throw new MpakCacheCorruptedError(
-          `Bundle uncompressed size (${Math.round(totalSize / 1024 / 1024)}MB) exceeds maximum allowed (${MAX_UNCOMPRESSED_SIZE / (1024 * 1024)}MB)`,
-          zipPath,
-        );
-      }
-    }
+    zipfile = await openZip(zipPath);
   } catch (error: unknown) {
-    if (error instanceof MpakCacheCorruptedError) {
-      throw error;
-    }
-    const message = error instanceof Error ? error.message : String(error);
     throw new MpakCacheCorruptedError(
-      `Cannot verify bundle size before extraction: ${message}`,
+      `Cannot open bundle archive: ${errorMessage(error)}`,
       zipPath,
       error instanceof Error ? error : undefined,
     );
   }
 
-  mkdirSync(destDir, { recursive: true });
-  execFileSync('unzip', ['-o', '-q', zipPath, '-d', destDir], {
-    stdio: 'pipe',
+  try {
+    let entries: Entry[];
+    try {
+      entries = await readAllEntries(zipfile);
+    } catch (error: unknown) {
+      throw new MpakCacheCorruptedError(
+        `Invalid bundle entry: ${errorMessage(error)}`,
+        zipPath,
+        error instanceof Error ? error : undefined,
+      );
+    }
+
+    const declaredTotal = entries.reduce((sum, e) => sum + e.uncompressedSize, 0);
+    if (declaredTotal > maxSize) {
+      throw new MpakCacheCorruptedError(
+        `Bundle uncompressed size (${formatMB(declaredTotal)}MB) exceeds maximum allowed (${formatMB(maxSize)}MB)`,
+        zipPath,
+      );
+    }
+
+    const normalizedDest = resolve(destDir);
+    mkdirSync(normalizedDest, { recursive: true });
+
+    let cumulativeBytes = 0;
+    for (const entry of entries) {
+      const safePath = resolveEntryPath(normalizedDest, entry.fileName, zipPath);
+
+      if (isSymlink(entry)) {
+        throw new MpakCacheCorruptedError(
+          `Bundle contains a symlink entry (${entry.fileName}); symlinks are not permitted`,
+          zipPath,
+        );
+      }
+
+      if (isDirectoryEntry(entry)) {
+        mkdirSync(safePath, { recursive: true });
+        continue;
+      }
+
+      mkdirSync(dirname(safePath), { recursive: true });
+
+      const readStream = await openReadStream(zipfile, entry);
+      const counter = createByteCounter(entry, zipPath, () => cumulativeBytes, maxSize, (n) => {
+        cumulativeBytes = n;
+      });
+
+      await pipeline(readStream, counter, createWriteStream(safePath));
+
+      const mode = unixMode(entry);
+      if (mode !== null) {
+        chmodSync(safePath, mode);
+      }
+    }
+  } finally {
+    zipfile.close();
+  }
+}
+
+function openZip(path: string): Promise<ZipFile> {
+  return new Promise((res, rej) => {
+    yauzl.open(path, { lazyEntries: false, autoClose: false }, (err, zipfile) => {
+      if (err || !zipfile) rej(err ?? new Error('yauzl returned no zipfile'));
+      else res(zipfile);
+    });
   });
+}
+
+function readAllEntries(zipfile: ZipFile): Promise<Entry[]> {
+  return new Promise((res, rej) => {
+    const entries: Entry[] = [];
+    zipfile.on('entry', (entry: Entry) => entries.push(entry));
+    zipfile.on('end', () => res(entries));
+    zipfile.on('error', rej);
+  });
+}
+
+function openReadStream(zipfile: ZipFile, entry: Entry): Promise<Readable> {
+  return new Promise((res, rej) => {
+    zipfile.openReadStream(entry, (err, stream) => {
+      if (err || !stream) rej(err ?? new Error('yauzl returned no read stream'));
+      else res(stream);
+    });
+  });
+}
+
+function resolveEntryPath(normalizedDest: string, entryName: string, zipPath: string): string {
+  if (entryName.includes('\0')) {
+    throw new MpakCacheCorruptedError(
+      `Bundle entry name contains NUL byte: ${JSON.stringify(entryName)}`,
+      zipPath,
+    );
+  }
+  const candidate = resolve(normalizedDest, entryName);
+  if (candidate !== normalizedDest && !candidate.startsWith(normalizedDest + sep)) {
+    throw new MpakCacheCorruptedError(
+      `Bundle entry escapes destination directory: ${entryName}`,
+      zipPath,
+    );
+  }
+  return candidate;
+}
+
+function isDirectoryEntry(entry: Entry): boolean {
+  return /\/$/.test(entry.fileName);
+}
+
+function isSymlink(entry: Entry): boolean {
+  const mode = entry.externalFileAttributes >>> 16;
+  // S_IFLNK = 0o120000; check the file-type bits
+  return (mode & 0o170000) === 0o120000;
+}
+
+function unixMode(entry: Entry): number | null {
+  const mode = (entry.externalFileAttributes >>> 16) & 0o7777;
+  return mode === 0 ? null : mode;
+}
+
+function createByteCounter(
+  entry: Entry,
+  zipPath: string,
+  getCumulative: () => number,
+  maxSize: number,
+  setCumulative: (n: number) => void,
+): Transform {
+  let entryBytes = 0;
+  return new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      entryBytes += chunk.length;
+      if (entryBytes > entry.uncompressedSize) {
+        cb(
+          new MpakCacheCorruptedError(
+            `Entry ${entry.fileName} exceeds its declared uncompressed size (possible zip bomb)`,
+            zipPath,
+          ),
+        );
+        return;
+      }
+      const next = getCumulative() + chunk.length;
+      if (next > maxSize) {
+        cb(
+          new MpakCacheCorruptedError(
+            `Bundle exceeds maximum uncompressed size (${formatMB(maxSize)}MB) during extraction`,
+            zipPath,
+          ),
+        );
+        return;
+      }
+      setCumulative(next);
+      cb(null, chunk);
+    },
+  });
+}
+
+function formatMB(bytes: number): number {
+  return Math.round(bytes / (1024 * 1024));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /**

--- a/packages/sdk-typescript/src/helpers.ts
+++ b/packages/sdk-typescript/src/helpers.ts
@@ -125,9 +125,15 @@ export async function extractZip(
 
       try {
         const readStream = await openReadStream(zipfile, entry);
-        const counter = createByteCounter(entry, zipPath, () => cumulativeBytes, maxSize, (n) => {
-          cumulativeBytes = n;
-        });
+        const counter = createByteCounter(
+          entry,
+          zipPath,
+          () => cumulativeBytes,
+          maxSize,
+          (n) => {
+            cumulativeBytes = n;
+          },
+        );
         await pipeline(readStream, counter, createWriteStream(safePath));
       } catch (error: unknown) {
         if (error instanceof MpakCacheCorruptedError) throw error;

--- a/packages/sdk-typescript/src/helpers.ts
+++ b/packages/sdk-typescript/src/helpers.ts
@@ -123,12 +123,20 @@ export async function extractZip(
 
       mkdirSync(dirname(safePath), { recursive: true });
 
-      const readStream = await openReadStream(zipfile, entry);
-      const counter = createByteCounter(entry, zipPath, () => cumulativeBytes, maxSize, (n) => {
-        cumulativeBytes = n;
-      });
-
-      await pipeline(readStream, counter, createWriteStream(safePath));
+      try {
+        const readStream = await openReadStream(zipfile, entry);
+        const counter = createByteCounter(entry, zipPath, () => cumulativeBytes, maxSize, (n) => {
+          cumulativeBytes = n;
+        });
+        await pipeline(readStream, counter, createWriteStream(safePath));
+      } catch (error: unknown) {
+        if (error instanceof MpakCacheCorruptedError) throw error;
+        throw new MpakCacheCorruptedError(
+          `Failed to extract entry ${entry.fileName}: ${errorMessage(error)}`,
+          zipPath,
+          error instanceof Error ? error : undefined,
+        );
+      }
 
       const mode = unixMode(entry);
       if (mode !== null) {
@@ -141,6 +149,9 @@ export async function extractZip(
 }
 
 function openZip(path: string): Promise<ZipFile> {
+  // lazyEntries: false — we need the full central directory before extraction
+  // to do the pre-write size cap check, so buffering entries up-front is
+  // intentional (memory cost scales with entry count, not file size).
   return new Promise((res, rej) => {
     yauzl.open(path, { lazyEntries: false, autoClose: false }, (err, zipfile) => {
       if (err || !zipfile) rej(err ?? new Error('yauzl returned no zipfile'));
@@ -195,7 +206,9 @@ function isSymlink(entry: Entry): boolean {
 }
 
 function unixMode(entry: Entry): number | null {
-  const mode = (entry.externalFileAttributes >>> 16) & 0o7777;
+  // Mask to the 9 permission bits only — strip setuid/setgid/sticky so a
+  // malicious bundle cannot land a setuid file on disk.
+  const mode = (entry.externalFileAttributes >>> 16) & 0o777;
   return mode === 0 ? null : mode;
 }
 

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -36,7 +36,7 @@ export type { MpakClientConfig } from './types.js';
 
 // Utilities
 export { parsePackageSpec } from './utils.js';
-export { MAX_UNCOMPRESSED_SIZE } from './helpers.js';
+export { MAX_UNCOMPRESSED_SIZE, extractZip, isSemverEqual } from './helpers.js';
 export type { ExtractZipOptions } from './helpers.js';
 
 // Errors

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -36,6 +36,8 @@ export type { MpakClientConfig } from './types.js';
 
 // Utilities
 export { parsePackageSpec } from './utils.js';
+export { MAX_UNCOMPRESSED_SIZE } from './helpers.js';
+export type { ExtractZipOptions } from './helpers.js';
 
 // Errors
 export {

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -30,6 +30,14 @@ export interface MpakOptions {
   timeout?: number;
   /** User-Agent string sent with every request. */
   userAgent?: string;
+  /**
+   * Maximum allowed uncompressed size (bytes) for any bundle this SDK
+   * extracts. Defaults to the SDK's built-in cap (see
+   * `MAX_UNCOMPRESSED_SIZE` in `helpers.ts`). Raise this for bundles that
+   * vendor heavy ML/Python dependencies; lower it to enforce a stricter
+   * policy.
+   */
+  maxUncompressedSize?: number;
 }
 
 /**
@@ -141,9 +149,13 @@ export class Mpak {
     this.client = new MpakClient(clientConfig);
 
     // initialize cache
-    this.bundleCache = new MpakBundleCache(this.client, {
+    const cacheOptions: { mpakHome: string; maxUncompressedSize?: number } = {
       mpakHome: this.configManager.mpakHome,
-    });
+    };
+    if (options?.maxUncompressedSize !== undefined) {
+      cacheOptions.maxUncompressedSize = options.maxUncompressedSize;
+    }
+    this.bundleCache = new MpakBundleCache(this.client, cacheOptions);
   }
 
   /**
@@ -252,7 +264,7 @@ export class Mpak {
       }
 
       try {
-        extractZip(absolutePath, cacheDir);
+        await extractZip(absolutePath, cacheDir, this.bundleCache.extractOptions());
       } catch (err) {
         throw new MpakInvalidBundleError(
           err instanceof Error ? err.message : String(err),

--- a/packages/sdk-typescript/tests/helpers.test.ts
+++ b/packages/sdk-typescript/tests/helpers.test.ts
@@ -1,10 +1,12 @@
 import { execFileSync } from 'node:child_process';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
@@ -40,8 +42,8 @@ describe('isSemverEqual', () => {
 });
 
 describe('constants', () => {
-  it('MAX_UNCOMPRESSED_SIZE is 500MB', () => {
-    expect(MAX_UNCOMPRESSED_SIZE).toBe(500 * 1024 * 1024);
+  it('MAX_UNCOMPRESSED_SIZE has a sensible default (>=1GB)', () => {
+    expect(MAX_UNCOMPRESSED_SIZE).toBeGreaterThanOrEqual(1024 * 1024 * 1024);
   });
 
   it('UPDATE_CHECK_TTL_MS is 1 hour', () => {
@@ -60,7 +62,7 @@ describe('extractZip', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('extracts a valid zip to the destination directory', () => {
+  it('extracts a valid zip to the destination directory', async () => {
     const srcDir = join(testDir, 'src');
     mkdirSync(srcDir);
     writeFileSync(join(srcDir, 'hello.txt'), 'hello world');
@@ -69,13 +71,13 @@ describe('extractZip', () => {
     execFileSync('zip', ['-j', zipPath, join(srcDir, 'hello.txt')], { stdio: 'pipe' });
 
     const destDir = join(testDir, 'dest');
-    extractZip(zipPath, destDir);
+    await extractZip(zipPath, destDir);
 
     expect(existsSync(join(destDir, 'hello.txt'))).toBe(true);
     expect(readFileSync(join(destDir, 'hello.txt'), 'utf8')).toBe('hello world');
   });
 
-  it('creates the destination directory if it does not exist', () => {
+  it('creates the destination directory if it does not exist', async () => {
     const srcDir = join(testDir, 'src');
     mkdirSync(srcDir);
     writeFileSync(join(srcDir, 'file.txt'), 'content');
@@ -84,17 +86,139 @@ describe('extractZip', () => {
     execFileSync('zip', ['-j', zipPath, join(srcDir, 'file.txt')], { stdio: 'pipe' });
 
     const destDir = join(testDir, 'nested', 'deep', 'dest');
-    extractZip(zipPath, destDir);
+    await extractZip(zipPath, destDir);
 
     expect(existsSync(join(destDir, 'file.txt'))).toBe(true);
   });
 
-  it('throws for an invalid zip file', () => {
+  it('preserves nested directory structure', async () => {
+    const srcDir = join(testDir, 'src');
+    mkdirSync(join(srcDir, 'a', 'b', 'c'), { recursive: true });
+    writeFileSync(join(srcDir, 'top.txt'), 'top');
+    writeFileSync(join(srcDir, 'a', 'b', 'c', 'deep.txt'), 'deep');
+
+    const zipPath = join(testDir, 'test.zip');
+    execFileSync('zip', ['-r', zipPath, '.'], { cwd: srcDir, stdio: 'pipe' });
+
+    const destDir = join(testDir, 'dest');
+    await extractZip(zipPath, destDir);
+
+    expect(readFileSync(join(destDir, 'top.txt'), 'utf8')).toBe('top');
+    expect(readFileSync(join(destDir, 'a', 'b', 'c', 'deep.txt'), 'utf8')).toBe('deep');
+  });
+
+  it('preserves executable bit on scripts', async () => {
+    const srcDir = join(testDir, 'src');
+    mkdirSync(srcDir);
+    const scriptPath = join(srcDir, 'run.sh');
+    writeFileSync(scriptPath, '#!/bin/sh\necho hi\n');
+    chmodSync(scriptPath, 0o755);
+
+    const zipPath = join(testDir, 'test.zip');
+    execFileSync('zip', ['-j', zipPath, scriptPath], { stdio: 'pipe' });
+
+    const destDir = join(testDir, 'dest');
+    await extractZip(zipPath, destDir);
+
+    const mode = statSync(join(destDir, 'run.sh')).mode & 0o777;
+    expect(mode & 0o100).toBe(0o100); // owner-executable
+  });
+
+  it('throws for an invalid zip file', async () => {
     const zipPath = join(testDir, 'bad.zip');
     writeFileSync(zipPath, 'not a zip');
 
-    expect(() => extractZip(zipPath, join(testDir, 'dest'))).toThrow(
-      'Cannot verify bundle size before extraction',
+    await expect(extractZip(zipPath, join(testDir, 'dest'))).rejects.toThrow(
+      'Cannot open bundle archive',
+    );
+  });
+
+  it('handles archives with many entries (no buffer limit regression)', async () => {
+    // The previous implementation shelled out to `unzip -l` with Node's
+    // default 1 MB maxBuffer, which blew up on archives with ~15K+ files.
+    // This test creates enough entries to have exceeded that limit.
+    const srcDir = join(testDir, 'src');
+    mkdirSync(srcDir);
+    const count = 20000;
+    for (let i = 0; i < count; i++) {
+      writeFileSync(join(srcDir, `f${i}.txt`), String(i));
+    }
+
+    const zipPath = join(testDir, 'many.zip');
+    execFileSync('zip', ['-r', '-0', zipPath, '.'], { cwd: srcDir, stdio: 'pipe' });
+
+    const destDir = join(testDir, 'dest');
+    await extractZip(zipPath, destDir);
+
+    expect(existsSync(join(destDir, 'f0.txt'))).toBe(true);
+    expect(existsSync(join(destDir, `f${count - 1}.txt`))).toBe(true);
+  }, 60_000);
+
+  it('rejects when total declared size exceeds the configured cap', async () => {
+    const srcDir = join(testDir, 'src');
+    mkdirSync(srcDir);
+    // 4 files × 1KB = 4KB declared total; cap at 2KB
+    const payload = 'x'.repeat(1024);
+    for (let i = 0; i < 4; i++) writeFileSync(join(srcDir, `f${i}.txt`), payload);
+
+    const zipPath = join(testDir, 'oversize.zip');
+    execFileSync('zip', ['-r', zipPath, '.'], { cwd: srcDir, stdio: 'pipe' });
+
+    await expect(
+      extractZip(zipPath, join(testDir, 'dest'), { maxUncompressedSize: 2048 }),
+    ).rejects.toThrow(/exceeds maximum allowed/);
+  });
+
+  it('accepts when total declared size is under the configured cap', async () => {
+    const srcDir = join(testDir, 'src');
+    mkdirSync(srcDir);
+    writeFileSync(join(srcDir, 'small.txt'), 'hi');
+
+    const zipPath = join(testDir, 'small.zip');
+    execFileSync('zip', ['-r', zipPath, '.'], { cwd: srcDir, stdio: 'pipe' });
+
+    await expect(
+      extractZip(zipPath, join(testDir, 'dest'), { maxUncompressedSize: 1024 * 1024 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects entries that escape the destination directory', async () => {
+    // Craft a zip containing a path-traversal entry. `zip` normalizes `..`
+    // out of relative paths, so we use Python to write the raw entry name.
+    const zipPath = join(testDir, 'traversal.zip');
+    execFileSync(
+      'python3',
+      [
+        '-c',
+        `import zipfile, sys\nwith zipfile.ZipFile(sys.argv[1], 'w') as z:\n  z.writestr('../escaped.txt', 'pwned')\n`,
+        zipPath,
+      ],
+      { stdio: 'pipe' },
+    );
+
+    // Rejection may come from yauzl's own `..` guard (wrapped as
+     // "Invalid bundle entry") or from our resolve-based check
+     // ("escapes destination directory"). Either proves traversal is blocked.
+    await expect(extractZip(zipPath, join(testDir, 'dest'))).rejects.toThrow(
+      /(escapes destination directory|Invalid bundle entry.*invalid relative path)/,
+    );
+  });
+
+  it('rejects archives containing symlink entries', async () => {
+    const zipPath = join(testDir, 'symlink.zip');
+    // Create a symlink entry via Python: external_attr encodes mode 0o120777.
+    execFileSync(
+      'python3',
+      [
+        '-c',
+        `import zipfile, sys\nzi = zipfile.ZipInfo('link')\nzi.create_system = 3\nzi.external_attr = (0o120777 << 16)\nwith zipfile.ZipFile(sys.argv[1], 'w') as z:\n  z.writestr(zi, 'target.txt')\n`,
+        zipPath,
+      ],
+      { stdio: 'pipe' },
+    );
+
+    await expect(extractZip(zipPath, join(testDir, 'dest'))).rejects.toThrow(
+      /symlinks are not permitted/,
     );
   });
 });

--- a/packages/sdk-typescript/tests/helpers.test.ts
+++ b/packages/sdk-typescript/tests/helpers.test.ts
@@ -197,8 +197,8 @@ describe('extractZip', () => {
     );
 
     // Rejection may come from yauzl's own `..` guard (wrapped as
-     // "Invalid bundle entry") or from our resolve-based check
-     // ("escapes destination directory"). Either proves traversal is blocked.
+    // "Invalid bundle entry") or from our resolve-based check
+    // ("escapes destination directory"). Either proves traversal is blocked.
     await expect(extractZip(zipPath, join(testDir, 'dest'))).rejects.toThrow(
       /(escapes destination directory|Invalid bundle entry.*invalid relative path)/,
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       '@nimblebrain/mpak-schemas':
         specifier: workspace:*
         version: link:../schemas
+      yauzl:
+        specifier: ^3.2.0
+        version: 3.3.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -298,6 +301,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10
+      '@types/yauzl':
+        specifier: ^2.10.3
+        version: 2.10.3
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -2076,6 +2082,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
   '@typescript-eslint/eslint-plugin@8.54.0':
     resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2502,6 +2511,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -4164,6 +4176,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
@@ -5422,6 +5437,10 @@ packages:
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
     engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
@@ -7662,6 +7681,10 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.10
+
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -8297,6 +8320,8 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
 
@@ -10359,6 +10384,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pend@1.2.0: {}
+
   perfect-debounce@1.0.0: {}
 
   pg-cloudflare@1.3.0:
@@ -11782,6 +11809,11 @@ snapshots:
   yaml@2.8.2: {}
 
   yargs-parser@21.1.1: {}
+
+  yauzl@3.3.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Closes #87.

## Summary

- Replaces the `unzip` shell-out in `extractZip` with a streaming, pure-JS implementation using `yauzl`. The previous implementation failed with `ENOBUFS` on any archive large enough to make `unzip -l` stdout exceed Node's default 1 MB maxBuffer (hit in production on an 18,769-file / 830 MB bundle) and enforced a hard-coded 500 MB cap that excluded bundles vendoring heavy Python/ML dependencies.
- `maxUncompressedSize` is now configurable via `ExtractZipOptions`, `MpakBundleCacheOptions`, and `MpakOptions`. Default raised from 500 MB to 2 GB.
- No more dependency on the `unzip` binary being on `PATH` (matters for minimal container images, Alpine without busybox-extras, Windows).

## What changed

- `extractZip` is now `async` and streams each entry to disk via `pipeline`, tracking per-entry and cumulative bytes written.
- **Two-phase zip-bomb protection:** declared total from the central directory is checked before any write; actual bytes written are checked during extraction (catches lying central directories).
- **Path-traversal guard:** each entry resolved against `destDir`; escapes rejected with `MpakCacheCorruptedError`.
- **Symlink entries rejected** (common attack vector, not needed in bundles).
- **Unix mode bits preserved** (matches prior `unzip -o -q` behavior for executable scripts).
- `yauzl`'s own validation errors wrapped in `MpakCacheCorruptedError` so consumers see uniform error semantics.
- `MAX_UNCOMPRESSED_SIZE` and `ExtractZipOptions` exported from the public API.

## Test plan

- [x] All 218 unit tests pass (`pnpm --filter @nimblebrain/mpak-sdk test`).
- [x] Typecheck clean (`pnpm --filter @nimblebrain/mpak-sdk typecheck`).
- [x] Lint clean (`pnpm --filter @nimblebrain/mpak-sdk lint`).
- [x] Build clean (`pnpm --filter @nimblebrain/mpak-sdk build`).
- [x] CLI (consumer of SDK) still typechecks.
- [x] New test: 20K-entry archive extracts successfully — proves ENOBUFS regression is gone.
- [x] New test: configurable cap rejects over and accepts under.
- [x] New test: path-traversal entry rejected.
- [x] New test: symlink entry rejected.
- [x] New test: nested directories preserved.
- [x] New test: executable bit preserved on scripts.
- [ ] Manual smoke test: install `@nimblebraininc/synapse-research@0.1.0` (the bundle from the original bug report) on the agent-platform.

## Notes for release

- This is a **breaking change to the `extractZip` signature** (sync → async). Both internal callers (`cache.ts`, `mpakSDK.ts`) are updated. External consumers importing `extractZip` directly will need to `await` it.
- `MAX_UNCOMPRESSED_SIZE` changed from 500 MB to 2 GB. Consumers relying on the old value should pass `maxUncompressedSize: 500 * 1024 * 1024` explicitly.
- Recommend a minor version bump at release time (0.5.0 → 0.6.0). Not bumped in this PR — leaving that for release coordination.
- Follow-up: the original issue suggested also dropping `execFileSync` entirely, which this PR does. No follow-up issue needed for that portion.