### PR TITLE
fix(cli): use namespaced commands in bundle show/search output

### DIFF
--- a/packages/cli/src/commands/packages/search.ts
+++ b/packages/cli/src/commands/packages/search.ts
@@ -43,7 +43,7 @@ export async function handleSearch(query: string, options: SearchOptions = {}): 
       logger.info(`More results available. Use --offset ${nextOffset} to see more.`);
     }
 
-    logger.info('Use "mpak show <bundle>" for more details');
+    logger.info('Use "mpak bundle show <bundle>" for more details');
   } catch (error) {
     logger.error(error instanceof Error ? error.message : 'Failed to search bundles');
   }

--- a/packages/cli/src/commands/packages/show.ts
+++ b/packages/cli/src/commands/packages/show.ts
@@ -136,7 +136,7 @@ export async function handleShow(packageName: string, options: ShowOptions = {})
 
     // Install instructions
     logger.info('Pull (download only):');
-    logger.info(`  mpak pull ${bundle.name}`);
+    logger.info(`  mpak bundle pull ${bundle.name}`);
   } catch (error) {
     logger.error(error instanceof Error ? error.message : 'Failed to get bundle details');
   }


### PR DESCRIPTION
## Summary
- `mpak bundle show` output now suggests `mpak bundle pull` instead of `mpak pull`
- `mpak bundle search` output now suggests `mpak bundle show` instead of `mpak show`

Closes #89

## Test plan
- [x] Run `mpak bundle search <query>` — verify help text says `mpak bundle show`
- [x] Run `mpak bundle show <name>` — verify pull instruction says `mpak bundle pull`

🤖 Generated with [Claude Code](https://claude.com/claude-code)