### PR TITLE
ci: auto-create GitHub Release after each publish

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'cli-v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -65,13 +69,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#cli-v}"
-          gh release create "$TAG" \
-            --title "@nimblebrain/mpak v$VERSION" \
-            --generate-notes \
-            --verify-tag
+          # Find the previous same-prefix tag so notes don't include sibling-package commits
+          PREV_TAG=$(git tag -l 'cli-v*' --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping create"
+          else
+            gh release create "$TAG" \
+              --title "@nimblebrain/mpak v$VERSION" \
+              --generate-notes \
+              ${PREV_TAG:+--notes-start-tag "$PREV_TAG"} \
+              --verify-tag
+          fi

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -57,3 +57,21 @@ jobs:
           pnpm pack
           npm publish nimblebrain-mpak-*.tgz --provenance --access public
         working-directory: packages/cli
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#cli-v}"
+          gh release create "$TAG" \
+            --title "@nimblebrain/mpak v$VERSION" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -91,3 +91,21 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+  release:
+    needs: publish-docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#scanner-v}"
+          gh release create "$TAG" \
+            --title "mpak-scanner v$VERSION" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'scanner-v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nimblebraininc/mpak-scanner
@@ -99,13 +103,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#scanner-v}"
-          gh release create "$TAG" \
-            --title "mpak-scanner v$VERSION" \
-            --generate-notes \
-            --verify-tag
+          # Find the previous same-prefix tag so notes don't include sibling-package commits
+          PREV_TAG=$(git tag -l 'scanner-v*' --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping create"
+          else
+            gh release create "$TAG" \
+              --title "mpak-scanner v$VERSION" \
+              --generate-notes \
+              ${PREV_TAG:+--notes-start-tag "$PREV_TAG"} \
+              --verify-tag
+          fi

--- a/.github/workflows/schemas-publish.yml
+++ b/.github/workflows/schemas-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'schemas-v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -65,13 +69,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#schemas-v}"
-          gh release create "$TAG" \
-            --title "@nimblebrain/mpak-schemas v$VERSION" \
-            --generate-notes \
-            --verify-tag
+          # Find the previous same-prefix tag so notes don't include sibling-package commits
+          PREV_TAG=$(git tag -l 'schemas-v*' --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping create"
+          else
+            gh release create "$TAG" \
+              --title "@nimblebrain/mpak-schemas v$VERSION" \
+              --generate-notes \
+              ${PREV_TAG:+--notes-start-tag "$PREV_TAG"} \
+              --verify-tag
+          fi

--- a/.github/workflows/schemas-publish.yml
+++ b/.github/workflows/schemas-publish.yml
@@ -57,3 +57,21 @@ jobs:
           pnpm pack
           npm publish nimblebrain-mpak-schemas-*.tgz --provenance --access public
         working-directory: packages/schemas
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#schemas-v}"
+          gh release create "$TAG" \
+            --title "@nimblebrain/mpak-schemas v$VERSION" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -55,3 +55,21 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/sdk-python/dist/
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#sdk-python-v}"
+          gh release create "$TAG" \
+            --title "mpak (Python SDK) v$VERSION" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'sdk-python-v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -63,13 +67,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#sdk-python-v}"
-          gh release create "$TAG" \
-            --title "mpak (Python SDK) v$VERSION" \
-            --generate-notes \
-            --verify-tag
+          # Find the previous same-prefix tag so notes don't include sibling-package commits
+          PREV_TAG=$(git tag -l 'sdk-python-v*' --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping create"
+          else
+            gh release create "$TAG" \
+              --title "mpak (Python SDK) v$VERSION" \
+              --generate-notes \
+              ${PREV_TAG:+--notes-start-tag "$PREV_TAG"} \
+              --verify-tag
+          fi

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'sdk-typescript-v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -66,13 +70,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#sdk-typescript-v}"
-          gh release create "$TAG" \
-            --title "@nimblebrain/mpak-sdk v$VERSION" \
-            --generate-notes \
-            --verify-tag
+          # Find the previous same-prefix tag so notes don't include sibling-package commits
+          PREV_TAG=$(git tag -l 'sdk-typescript-v*' --sort=-v:refname | grep -v "^${TAG}$" | head -n1)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping create"
+          else
+            gh release create "$TAG" \
+              --title "@nimblebrain/mpak-sdk v$VERSION" \
+              --generate-notes \
+              ${PREV_TAG:+--notes-start-tag "$PREV_TAG"} \
+              --verify-tag
+          fi

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -58,3 +58,21 @@ jobs:
           pnpm pack
           npm publish nimblebrain-mpak-sdk-*.tgz --provenance --access public
         working-directory: packages/sdk-typescript
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#sdk-typescript-v}"
+          gh release create "$TAG" \
+            --title "@nimblebrain/mpak-sdk v$VERSION" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## Summary

After PR #94 shipped without a corresponding GitHub Release page (because the project has historically been tag-only), we created the three releases for this round (`schemas-v0.3.0`, `sdk-typescript-v0.7.0`, `cli-v0.4.2`) by hand. This PR removes the manual step going forward.

Each `*-publish.yml` workflow gets a new `release` job that runs after the npm/PyPI/GHCR publish completes. It runs `gh release create --generate-notes --verify-tag`, which builds the release body from PR titles merged since the previous tag.

## Why

- **Discoverability**: GitHub renders Releases in the repo sidebar; tags are buried two clicks deep
- **Watcher notifications**: users who "Watch → Releases only" get pinged on each release
- **External linkability**: blog posts / Discord can link to a release URL with a curated narrative
- **Standard expectation** for an OSS registry product

## Design choices

- **Separate `release` job** rather than an extra step in `publish`. Keeps the publish job's permissions narrow (`id-token: write` only) and the release job's permissions narrow (`contents: write` only). Also makes the release re-runnable from the GH UI if it fails independently of publish.
- **Scanner waits on `publish-docker`**, which transitively waits on `publish-pypi`, so PyPI + GHCR + GitHub Release are all aligned.
- **Tag prefix stripping**: each workflow uses its own tag prefix (`schemas-v`, `sdk-typescript-v`, `cli-v`, `sdk-python-v`, `scanner-v`) to derive the version for the release title.
- **No backfill**: existing historical tags stay tag-only. The three releases for this round were created by hand; from the next tag forward, CI handles it.

## Test plan

- [ ] Workflow YAML parses (verified locally — all 5 load cleanly)
- [ ] On the next tag push (per-package), CI creates a Release with a sensible auto-generated body. Each workflow can be tested in isolation by tagging a patch bump.

## Files changed

- `.github/workflows/cli-publish.yml`
- `.github/workflows/schemas-publish.yml`
- `.github/workflows/sdk-typescript-publish.yml`
- `.github/workflows/sdk-python-publish.yml`
- `.github/workflows/scanner-publish.yml`