### PR TITLE
fix(sdk): honor manifest python command, ABI-validate before spawn

### DIFF
--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -1,11 +1,11 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 // =============================================================================
 // Manifest Building Blocks
 // =============================================================================
 
 /** Server runtime type (v0.4 added "uv"). */
-export const ServerTypeSchema = z.enum(["node", "python", "binary", "uv"]);
+export const ServerTypeSchema = z.enum(['node', 'python', 'binary', 'uv']);
 
 /**
  * A path that must resolve to a location within the bundle root.
@@ -23,33 +23,31 @@ export const ServerTypeSchema = z.enum(["node", "python", "binary", "uv"]);
  */
 export const SafeRelativePathSchema = z
   .string()
-  .min(1, "must not be empty")
-  .refine((p) => !p.includes("\0"), {
-    message: "must not contain NUL bytes",
+  .min(1, 'must not be empty')
+  .refine((p) => !p.includes('\0'), {
+    message: 'must not contain NUL bytes',
   })
-  .refine((p) => !p.includes("\\"), {
+  .refine((p) => !p.includes('\\'), {
     // MCPB bundles are zip archives; ZIP central directories use forward slashes.
     // Rejecting all backslashes blocks Windows-style traversal forms (`\foo`,
     // `C:\foo`, `\\server\share`, `foo\..\bar`) without needing per-form rules.
-    message:
-      "must use forward slashes only (backslashes are not permitted)",
+    message: 'must use forward slashes only (backslashes are not permitted)',
   })
   .refine(
     (p) => {
-      if (p.startsWith("/")) return false; // POSIX absolute
+      if (p.startsWith('/')) return false; // POSIX absolute
       if (/^[a-zA-Z]:/.test(p)) return false; // Windows drive (with or without separator)
-      if (p.split("/").includes("..")) return false; // traversal segment
+      if (p.split('/').includes('..')) return false; // traversal segment
       return true;
     },
     {
-      message:
-        'must be a relative path within the bundle (no absolute paths or ".." segments)',
+      message: 'must be a relative path within the bundle (no absolute paths or ".." segments)',
     },
   );
 
 /** User-configurable field declared by a bundle author. */
 export const UserConfigFieldSchema = z.object({
-  type: z.enum(["string", "number", "boolean"]),
+  type: z.enum(['string', 'number', 'boolean']),
   title: z.string().optional(),
   description: z.string().optional(),
   sensitive: z.boolean().optional(),
@@ -95,9 +93,7 @@ export const CompatibilitySchema = z
     // `PlatformSchema` in package.ts but importing it here would create a
     // module cycle (package.ts already imports `ServerTypeSchema` from this
     // file). Three strings; not worth a shared module.
-    platforms: z
-      .array(z.enum(["darwin", "win32", "linux"]))
-      .optional(),
+    platforms: z.array(z.enum(['darwin', 'win32', 'linux'])).optional(),
     runtimes: CompatibilityRuntimesSchema.optional(),
   })
   .catchall(z.string());

--- a/packages/schemas/src/manifest.ts
+++ b/packages/schemas/src/manifest.ts
@@ -57,12 +57,50 @@ export const UserConfigFieldSchema = z.object({
   default: z.union([z.string(), z.number(), z.boolean()]).optional(),
 });
 
-/** MCP server launch configuration (command, args, env). */
+/**
+ * MCP server launch configuration (command, args, env).
+ *
+ * `command` is optional per MCPB v0.4 — for `type: "uv"` the spec lets the
+ * host manage execution, in which case the bundle may omit `mcp_config`
+ * entirely. When present and `command` is omitted, the resolver supplies a
+ * sensible default for the server type.
+ */
 export const McpConfigSchema = z.object({
-  command: z.string(),
-  args: z.array(z.string()),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
   env: z.record(z.string(), z.string()).optional(),
 });
+
+/**
+ * Runtime version requirements (`compatibility.runtimes`).
+ *
+ * Each value is a semver range (e.g. `">=3.13,<4.0"`). Bundle authors only
+ * declare runtimes their bundle actually uses.
+ */
+export const CompatibilityRuntimesSchema = z.object({
+  python: z.string().optional(),
+  node: z.string().optional(),
+});
+
+/**
+ * Compatibility block.
+ *
+ * Known fields (`platforms`, `runtimes`) are typed; unknown keys are treated
+ * as client version constraints (e.g. `claude_desktop: ">=1.0.0"`,
+ * `my_client: ">1.0.0"`) and pass through as semver strings, per MCPB spec.
+ */
+export const CompatibilitySchema = z
+  .object({
+    // Inlined `z.enum(["darwin", "win32", "linux"])` — the same enum exists as
+    // `PlatformSchema` in package.ts but importing it here would create a
+    // module cycle (package.ts already imports `ServerTypeSchema` from this
+    // file). Three strings; not worth a shared module.
+    platforms: z
+      .array(z.enum(["darwin", "win32", "linux"]))
+      .optional(),
+    runtimes: CompatibilityRuntimesSchema.optional(),
+  })
+  .catchall(z.string());
 
 /** Author information. */
 export const ManifestAuthorSchema = z.object({
@@ -71,11 +109,18 @@ export const ManifestAuthorSchema = z.object({
   url: z.string().optional(),
 });
 
-/** Server configuration block. */
+/**
+ * Server configuration block.
+ *
+ * `mcp_config` is optional per MCPB v0.4 — `type: "uv"` bundles may omit it
+ * entirely and let the host manage execution.
+ */
 export const ManifestServerSchema = z.object({
   type: ServerTypeSchema,
   entry_point: SafeRelativePathSchema,
-  mcp_config: McpConfigSchema,
+  // Optional per MCPB v0.4 — `type: "uv"` bundles may omit and let
+  // the host manage execution.
+  mcp_config: McpConfigSchema.optional(),
 });
 
 /** MCP capability descriptor (tool, prompt, or resource). */
@@ -112,6 +157,7 @@ export const McpbManifestSchema = z.object({
     .optional(),
   user_config: z.record(z.string(), UserConfigFieldSchema).optional(),
   server: ManifestServerSchema,
+  compatibility: CompatibilitySchema.optional(),
   tools: z.array(CapabilitySchema).optional(),
   prompts: z.array(CapabilitySchema).optional(),
   resources: z.array(CapabilitySchema).optional(),
@@ -125,6 +171,8 @@ export const McpbManifestSchema = z.object({
 export type ServerType = z.infer<typeof ServerTypeSchema>;
 export type UserConfigField = z.infer<typeof UserConfigFieldSchema>;
 export type McpConfig = z.infer<typeof McpConfigSchema>;
+export type CompatibilityRuntimes = z.infer<typeof CompatibilityRuntimesSchema>;
+export type Compatibility = z.infer<typeof CompatibilitySchema>;
 export type ManifestAuthor = z.infer<typeof ManifestAuthorSchema>;
 export type ManifestServer = z.infer<typeof ManifestServerSchema>;
 export type Capability = z.infer<typeof CapabilitySchema>;

--- a/packages/schemas/tests/manifest.test.ts
+++ b/packages/schemas/tests/manifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
 import {
   CompatibilityRuntimesSchema,
@@ -7,106 +7,104 @@ import {
   McpbManifestSchema,
   McpConfigSchema,
   SafeRelativePathSchema,
-} from "../src/manifest.js";
+} from '../src/manifest.js';
 
-describe("SafeRelativePathSchema", () => {
-  describe("accepts safe relative paths", () => {
+describe('SafeRelativePathSchema', () => {
+  describe('accepts safe relative paths', () => {
     it.each([
-      "index.js",
-      "./index.js",
-      "src/index.js",
-      "build/server/main.js",
-      "main.py",
-      "mcp_echo.server",
-      "bin/run",
-      "deeply/nested/path/to/file.js",
-      "name-with-dashes.js",
-      "name_with_underscores.js",
-      "file.with.many.dots.js",
-      "ünicode/файл.js",
-    ])("accepts %j", (path) => {
+      'index.js',
+      './index.js',
+      'src/index.js',
+      'build/server/main.js',
+      'main.py',
+      'mcp_echo.server',
+      'bin/run',
+      'deeply/nested/path/to/file.js',
+      'name-with-dashes.js',
+      'name_with_underscores.js',
+      'file.with.many.dots.js',
+      'ünicode/файл.js',
+    ])('accepts %j', (path) => {
       expect(SafeRelativePathSchema.safeParse(path).success).toBe(true);
     });
   });
 
-  describe("rejects unsafe paths", () => {
+  describe('rejects unsafe paths', () => {
     it.each([
-      ["empty string", ""],
-      ["NUL byte", "foo\0bar"],
-      ["POSIX absolute", "/etc/passwd"],
-      ["POSIX absolute root", "/"],
-      ["dotdot at start", "../foo"],
-      ["dotdot in middle", "foo/../bar"],
-      ["dotdot at end", "foo/.."],
-      ["multiple dotdot", "../../../etc/passwd"],
-      ["windows drive", "C:\\evil"],
-      ["windows drive forward slash", "C:/evil"],
-      ["windows drive lowercase", "c:\\evil"],
-      ["windows drive without separator", "C:foo"],
-      ["windows drive-root-relative", "\\foo"],
-      ["windows UNC", "\\\\server\\share"],
-      ["dotdot via backslash", "foo\\..\\bar"],
-      ["any backslash", "foo\\bar"],
-    ])("rejects %s (%j)", (_label, path) => {
+      ['empty string', ''],
+      ['NUL byte', 'foo\0bar'],
+      ['POSIX absolute', '/etc/passwd'],
+      ['POSIX absolute root', '/'],
+      ['dotdot at start', '../foo'],
+      ['dotdot in middle', 'foo/../bar'],
+      ['dotdot at end', 'foo/..'],
+      ['multiple dotdot', '../../../etc/passwd'],
+      ['windows drive', 'C:\\evil'],
+      ['windows drive forward slash', 'C:/evil'],
+      ['windows drive lowercase', 'c:\\evil'],
+      ['windows drive without separator', 'C:foo'],
+      ['windows drive-root-relative', '\\foo'],
+      ['windows UNC', '\\\\server\\share'],
+      ['dotdot via backslash', 'foo\\..\\bar'],
+      ['any backslash', 'foo\\bar'],
+    ])('rejects %s (%j)', (_label, path) => {
       expect(SafeRelativePathSchema.safeParse(path).success).toBe(false);
     });
   });
 
   it("does not reject paths that merely contain '..' as a substring", () => {
-    expect(SafeRelativePathSchema.safeParse("foo..bar.js").success).toBe(true);
-    expect(SafeRelativePathSchema.safeParse("..hidden/file.js").success).toBe(
-      true,
-    );
+    expect(SafeRelativePathSchema.safeParse('foo..bar.js').success).toBe(true);
+    expect(SafeRelativePathSchema.safeParse('..hidden/file.js').success).toBe(true);
   });
 });
 
-describe("McpConfigSchema", () => {
-  it("accepts a fully populated mcp_config", () => {
+describe('McpConfigSchema', () => {
+  it('accepts a fully populated mcp_config', () => {
     const result = McpConfigSchema.safeParse({
-      command: "uv",
-      args: ["run", "src/server.py"],
-      env: { FOO: "bar" },
+      command: 'uv',
+      args: ['run', 'src/server.py'],
+      env: { FOO: 'bar' },
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts mcp_config with no command (MCPB v0.4 — host-managed)", () => {
+  it('accepts mcp_config with no command (MCPB v0.4 — host-managed)', () => {
     const result = McpConfigSchema.safeParse({
-      args: ["run", "src/server.py"],
+      args: ['run', 'src/server.py'],
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts mcp_config with no args", () => {
+  it('accepts mcp_config with no args', () => {
     // Some uv bundles supply only `command` and rely on resolver defaults for args.
-    const result = McpConfigSchema.safeParse({ command: "uv" });
+    const result = McpConfigSchema.safeParse({ command: 'uv' });
     expect(result.success).toBe(true);
   });
 
-  it("accepts an empty mcp_config object", () => {
+  it('accepts an empty mcp_config object', () => {
     const result = McpConfigSchema.safeParse({});
     expect(result.success).toBe(true);
   });
 });
 
-describe("ManifestServerSchema", () => {
+describe('ManifestServerSchema', () => {
   const validServer = {
-    type: "node" as const,
-    entry_point: "src/index.js",
+    type: 'node' as const,
+    entry_point: 'src/index.js',
     mcp_config: {
-      command: "node",
-      args: ["${__dirname}/src/index.js"],
+      command: 'node',
+      args: ['${__dirname}/src/index.js'],
     },
   };
 
-  it("accepts a clean relative entry_point", () => {
+  it('accepts a clean relative entry_point', () => {
     expect(ManifestServerSchema.safeParse(validServer).success).toBe(true);
   });
 
-  it("rejects an entry_point with .. traversal", () => {
+  it('rejects an entry_point with .. traversal', () => {
     const result = ManifestServerSchema.safeParse({
       ...validServer,
-      entry_point: "../../etc/passwd",
+      entry_point: '../../etc/passwd',
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -114,100 +112,100 @@ describe("ManifestServerSchema", () => {
     }
   });
 
-  it("rejects an absolute entry_point", () => {
+  it('rejects an absolute entry_point', () => {
     expect(
       ManifestServerSchema.safeParse({
         ...validServer,
-        entry_point: "/etc/passwd",
+        entry_point: '/etc/passwd',
       }).success,
     ).toBe(false);
   });
 
-  it("rejects an empty entry_point", () => {
+  it('rejects an empty entry_point', () => {
     expect(
       ManifestServerSchema.safeParse({
         ...validServer,
-        entry_point: "",
+        entry_point: '',
       }).success,
     ).toBe(false);
   });
 
-  it("accepts type:uv server with no mcp_config (host-managed execution)", () => {
+  it('accepts type:uv server with no mcp_config (host-managed execution)', () => {
     const result = ManifestServerSchema.safeParse({
-      type: "uv",
-      entry_point: "src/server.py",
+      type: 'uv',
+      entry_point: 'src/server.py',
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts type:python server with full mcp_config", () => {
+  it('accepts type:python server with full mcp_config', () => {
     const result = ManifestServerSchema.safeParse({
-      type: "python",
-      entry_point: "src/server.py",
+      type: 'python',
+      entry_point: 'src/server.py',
       mcp_config: {
-        command: "python",
-        args: ["-m", "my_pkg.server"],
+        command: 'python',
+        args: ['-m', 'my_pkg.server'],
       },
     });
     expect(result.success).toBe(true);
   });
 
-  it("rejects servers missing entry_point", () => {
-    const result = ManifestServerSchema.safeParse({ type: "node" });
+  it('rejects servers missing entry_point', () => {
+    const result = ManifestServerSchema.safeParse({ type: 'node' });
     expect(result.success).toBe(false);
   });
 });
 
-describe("CompatibilityRuntimesSchema", () => {
-  it("accepts python and node version constraints", () => {
+describe('CompatibilityRuntimesSchema', () => {
+  it('accepts python and node version constraints', () => {
     const result = CompatibilityRuntimesSchema.safeParse({
-      python: ">=3.13,<4.0",
-      node: ">=20.0.0",
+      python: '>=3.13,<4.0',
+      node: '>=20.0.0',
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts only python (bundle authors declare what they use)", () => {
+  it('accepts only python (bundle authors declare what they use)', () => {
     const result = CompatibilityRuntimesSchema.safeParse({
-      python: ">=3.10",
+      python: '>=3.10',
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts an empty runtimes block", () => {
+  it('accepts an empty runtimes block', () => {
     const result = CompatibilityRuntimesSchema.safeParse({});
     expect(result.success).toBe(true);
   });
 });
 
-describe("CompatibilitySchema", () => {
+describe('CompatibilitySchema', () => {
   it("accepts the spec's full example shape", () => {
     const result = CompatibilitySchema.safeParse({
-      claude_desktop: ">=1.0.0",
-      my_client: ">1.0.0",
-      other_client: ">=2.0.0 <3.0.0",
-      platforms: ["darwin", "win32", "linux"],
+      claude_desktop: '>=1.0.0',
+      my_client: '>1.0.0',
+      other_client: '>=2.0.0 <3.0.0',
+      platforms: ['darwin', 'win32', 'linux'],
       runtimes: {
-        python: ">=3.8",
-        node: ">=16.0.0",
+        python: '>=3.8',
+        node: '>=16.0.0',
       },
     });
     expect(result.success).toBe(true);
     if (result.success) {
       // Unknown client constraints pass through via catchall.
-      expect(result.data.claude_desktop).toBe(">=1.0.0");
-      expect(result.data.runtimes?.python).toBe(">=3.8");
+      expect(result.data.claude_desktop).toBe('>=1.0.0');
+      expect(result.data.runtimes?.python).toBe('>=3.8');
     }
   });
 
-  it("rejects invalid platform values", () => {
+  it('rejects invalid platform values', () => {
     const result = CompatibilitySchema.safeParse({
-      platforms: ["beos"],
+      platforms: ['beos'],
     });
     expect(result.success).toBe(false);
   });
 
-  it("rejects non-string client version constraints (catchall enforces string)", () => {
+  it('rejects non-string client version constraints (catchall enforces string)', () => {
     const result = CompatibilitySchema.safeParse({
       claude_desktop: 123,
     });
@@ -215,100 +213,96 @@ describe("CompatibilitySchema", () => {
   });
 });
 
-describe("McpbManifestSchema", () => {
+describe('McpbManifestSchema', () => {
   const baseManifest = {
-    manifest_version: "0.4",
-    name: "@test/bundle",
-    version: "1.0.0",
-    description: "test",
+    manifest_version: '0.4',
+    name: '@test/bundle',
+    version: '1.0.0',
+    description: 'test',
     server: {
-      type: "node",
-      entry_point: "build/index.js",
+      type: 'node',
+      entry_point: 'build/index.js',
       mcp_config: {
-        command: "node",
-        args: ["${__dirname}/build/index.js"],
+        command: 'node',
+        args: ['${__dirname}/build/index.js'],
       },
     },
   };
 
-  it("accepts a well-formed manifest", () => {
+  it('accepts a well-formed manifest', () => {
     expect(McpbManifestSchema.safeParse(baseManifest).success).toBe(true);
   });
 
-  it("rejects a manifest whose entry_point traverses out of the bundle", () => {
+  it('rejects a manifest whose entry_point traverses out of the bundle', () => {
     const result = McpbManifestSchema.safeParse({
       ...baseManifest,
-      server: { ...baseManifest.server, entry_point: "../../../../etc/passwd" },
+      server: { ...baseManifest.server, entry_point: '../../../../etc/passwd' },
     });
     expect(result.success).toBe(false);
   });
 
-  it("accepts a v0.3 type:python manifest (backward compatibility)", () => {
+  it('accepts a v0.3 type:python manifest (backward compatibility)', () => {
     const result = McpbManifestSchema.safeParse({
-      manifest_version: "0.3",
-      name: "legacy-bundle",
-      version: "1.0.0",
-      description: "v0.3 bundle with vendored deps",
+      manifest_version: '0.3',
+      name: 'legacy-bundle',
+      version: '1.0.0',
+      description: 'v0.3 bundle with vendored deps',
       server: {
-        type: "python",
-        entry_point: "src/server.py",
+        type: 'python',
+        entry_point: 'src/server.py',
         mcp_config: {
-          command: "python",
-          args: ["-m", "legacy.server"],
+          command: 'python',
+          args: ['-m', 'legacy.server'],
         },
       },
     });
     expect(result.success).toBe(true);
   });
 
-  it("accepts the canonical hello-world-uv manifest from the MCPB spec", () => {
+  it('accepts the canonical hello-world-uv manifest from the MCPB spec', () => {
     // Verbatim from anthropics/mcpb examples/hello-world-uv/manifest.json.
     // If this stops parsing, mpak has drifted from the upstream spec.
     const result = McpbManifestSchema.safeParse({
-      manifest_version: "0.4",
-      name: "hello-world-uv",
-      display_name: "Hello World (UV Runtime)",
-      version: "1.0.0",
-      description: "Simple MCP server using UV runtime",
-      author: { name: "Anthropic" },
-      icon: "icon.png",
+      manifest_version: '0.4',
+      name: 'hello-world-uv',
+      display_name: 'Hello World (UV Runtime)',
+      version: '1.0.0',
+      description: 'Simple MCP server using UV runtime',
+      author: { name: 'Anthropic' },
+      icon: 'icon.png',
       server: {
-        type: "uv",
-        entry_point: "src/server.py",
+        type: 'uv',
+        entry_point: 'src/server.py',
         mcp_config: {
-          command: "uv",
-          args: ["run", "--directory", "${__dirname}", "src/server.py"],
+          command: 'uv',
+          args: ['run', '--directory', '${__dirname}', 'src/server.py'],
         },
       },
       compatibility: {
-        platforms: ["darwin", "linux", "win32"],
-        runtimes: { python: ">=3.10" },
+        platforms: ['darwin', 'linux', 'win32'],
+        runtimes: { python: '>=3.10' },
       },
-      keywords: ["example", "hello-world", "uv"],
-      license: "MIT",
+      keywords: ['example', 'hello-world', 'uv'],
+      license: 'MIT',
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.compatibility?.runtimes?.python).toBe(">=3.10");
-      expect(result.data.compatibility?.platforms).toEqual([
-        "darwin",
-        "linux",
-        "win32",
-      ]);
+      expect(result.data.compatibility?.runtimes?.python).toBe('>=3.10');
+      expect(result.data.compatibility?.platforms).toEqual(['darwin', 'linux', 'win32']);
     }
   });
 
-  it("accepts a host-managed type:uv bundle that omits mcp_config entirely", () => {
+  it('accepts a host-managed type:uv bundle that omits mcp_config entirely', () => {
     const result = McpbManifestSchema.safeParse({
-      manifest_version: "0.4",
-      name: "minimal-uv",
-      version: "0.1.0",
-      description: "uv bundle delegating execution to the host",
+      manifest_version: '0.4',
+      name: 'minimal-uv',
+      version: '0.1.0',
+      description: 'uv bundle delegating execution to the host',
       server: {
-        type: "uv",
-        entry_point: "src/server.py",
+        type: 'uv',
+        entry_point: 'src/server.py',
       },
-      compatibility: { runtimes: { python: ">=3.13" } },
+      compatibility: { runtimes: { python: '>=3.13' } },
     });
     expect(result.success).toBe(true);
   });

--- a/packages/schemas/tests/manifest.test.ts
+++ b/packages/schemas/tests/manifest.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CompatibilityRuntimesSchema,
+  CompatibilitySchema,
   ManifestServerSchema,
   McpbManifestSchema,
+  McpConfigSchema,
   SafeRelativePathSchema,
 } from "../src/manifest.js";
 
@@ -57,6 +60,35 @@ describe("SafeRelativePathSchema", () => {
   });
 });
 
+describe("McpConfigSchema", () => {
+  it("accepts a fully populated mcp_config", () => {
+    const result = McpConfigSchema.safeParse({
+      command: "uv",
+      args: ["run", "src/server.py"],
+      env: { FOO: "bar" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts mcp_config with no command (MCPB v0.4 — host-managed)", () => {
+    const result = McpConfigSchema.safeParse({
+      args: ["run", "src/server.py"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts mcp_config with no args", () => {
+    // Some uv bundles supply only `command` and rely on resolver defaults for args.
+    const result = McpConfigSchema.safeParse({ command: "uv" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty mcp_config object", () => {
+    const result = McpConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
 describe("ManifestServerSchema", () => {
   const validServer = {
     type: "node" as const,
@@ -99,6 +131,88 @@ describe("ManifestServerSchema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("accepts type:uv server with no mcp_config (host-managed execution)", () => {
+    const result = ManifestServerSchema.safeParse({
+      type: "uv",
+      entry_point: "src/server.py",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts type:python server with full mcp_config", () => {
+    const result = ManifestServerSchema.safeParse({
+      type: "python",
+      entry_point: "src/server.py",
+      mcp_config: {
+        command: "python",
+        args: ["-m", "my_pkg.server"],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects servers missing entry_point", () => {
+    const result = ManifestServerSchema.safeParse({ type: "node" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("CompatibilityRuntimesSchema", () => {
+  it("accepts python and node version constraints", () => {
+    const result = CompatibilityRuntimesSchema.safeParse({
+      python: ">=3.13,<4.0",
+      node: ">=20.0.0",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts only python (bundle authors declare what they use)", () => {
+    const result = CompatibilityRuntimesSchema.safeParse({
+      python: ">=3.10",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty runtimes block", () => {
+    const result = CompatibilityRuntimesSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("CompatibilitySchema", () => {
+  it("accepts the spec's full example shape", () => {
+    const result = CompatibilitySchema.safeParse({
+      claude_desktop: ">=1.0.0",
+      my_client: ">1.0.0",
+      other_client: ">=2.0.0 <3.0.0",
+      platforms: ["darwin", "win32", "linux"],
+      runtimes: {
+        python: ">=3.8",
+        node: ">=16.0.0",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Unknown client constraints pass through via catchall.
+      expect(result.data.claude_desktop).toBe(">=1.0.0");
+      expect(result.data.runtimes?.python).toBe(">=3.8");
+    }
+  });
+
+  it("rejects invalid platform values", () => {
+    const result = CompatibilitySchema.safeParse({
+      platforms: ["beos"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-string client version constraints (catchall enforces string)", () => {
+    const result = CompatibilitySchema.safeParse({
+      claude_desktop: 123,
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("McpbManifestSchema", () => {
@@ -127,5 +241,75 @@ describe("McpbManifestSchema", () => {
       server: { ...baseManifest.server, entry_point: "../../../../etc/passwd" },
     });
     expect(result.success).toBe(false);
+  });
+
+  it("accepts a v0.3 type:python manifest (backward compatibility)", () => {
+    const result = McpbManifestSchema.safeParse({
+      manifest_version: "0.3",
+      name: "legacy-bundle",
+      version: "1.0.0",
+      description: "v0.3 bundle with vendored deps",
+      server: {
+        type: "python",
+        entry_point: "src/server.py",
+        mcp_config: {
+          command: "python",
+          args: ["-m", "legacy.server"],
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the canonical hello-world-uv manifest from the MCPB spec", () => {
+    // Verbatim from anthropics/mcpb examples/hello-world-uv/manifest.json.
+    // If this stops parsing, mpak has drifted from the upstream spec.
+    const result = McpbManifestSchema.safeParse({
+      manifest_version: "0.4",
+      name: "hello-world-uv",
+      display_name: "Hello World (UV Runtime)",
+      version: "1.0.0",
+      description: "Simple MCP server using UV runtime",
+      author: { name: "Anthropic" },
+      icon: "icon.png",
+      server: {
+        type: "uv",
+        entry_point: "src/server.py",
+        mcp_config: {
+          command: "uv",
+          args: ["run", "--directory", "${__dirname}", "src/server.py"],
+        },
+      },
+      compatibility: {
+        platforms: ["darwin", "linux", "win32"],
+        runtimes: { python: ">=3.10" },
+      },
+      keywords: ["example", "hello-world", "uv"],
+      license: "MIT",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.compatibility?.runtimes?.python).toBe(">=3.10");
+      expect(result.data.compatibility?.platforms).toEqual([
+        "darwin",
+        "linux",
+        "win32",
+      ]);
+    }
+  });
+
+  it("accepts a host-managed type:uv bundle that omits mcp_config entirely", () => {
+    const result = McpbManifestSchema.safeParse({
+      manifest_version: "0.4",
+      name: "minimal-uv",
+      version: "0.1.0",
+      description: "uv bundle delegating execution to the host",
+      server: {
+        type: "uv",
+        entry_point: "src/server.py",
+      },
+      compatibility: { runtimes: { python: ">=3.13" } },
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -408,7 +408,12 @@ export class Mpak {
     cacheDir: string,
     userConfigValues: Record<string, string>,
   ): { command: string; args: string[]; env: Record<string, string> } {
-    const { type, entry_point, mcp_config } = manifest.server;
+    const { type, entry_point } = manifest.server;
+    // `mcp_config` is optional (MCPB v0.4 lets `type: "uv"` bundles omit it);
+    // normalize to an empty object so each case can reach for command/args/env
+    // without re-guarding undefined.
+    const mcp_config = manifest.server.mcp_config ?? {};
+    const userArgs = mcp_config.args ?? [];
 
     // Substitute user_config placeholders in manifest env
     const env = Mpak.substituteEnvVars(mcp_config.env, userConfigValues);
@@ -419,7 +424,7 @@ export class Mpak {
     switch (type) {
       case 'binary': {
         command = join(cacheDir, entry_point);
-        args = Mpak.resolveArgs(mcp_config.args ?? [], cacheDir);
+        args = Mpak.resolveArgs(userArgs, cacheDir);
         try {
           chmodSync(command, 0o755);
         } catch {
@@ -431,8 +436,8 @@ export class Mpak {
       case 'node': {
         command = mcp_config.command || 'node';
         args =
-          mcp_config.args.length > 0
-            ? Mpak.resolveArgs(mcp_config.args, cacheDir)
+          userArgs.length > 0
+            ? Mpak.resolveArgs(userArgs, cacheDir)
             : [join(cacheDir, entry_point)];
         break;
       }
@@ -443,8 +448,8 @@ export class Mpak {
             ? Mpak.findPythonCommand()
             : mcp_config.command || Mpak.findPythonCommand();
         args =
-          mcp_config.args.length > 0
-            ? Mpak.resolveArgs(mcp_config.args, cacheDir)
+          userArgs.length > 0
+            ? Mpak.resolveArgs(userArgs, cacheDir)
             : [join(cacheDir, entry_point)];
 
         // Set PYTHONPATH to deps/ directory
@@ -456,8 +461,8 @@ export class Mpak {
       case 'uv': {
         command = mcp_config.command || 'uv';
         args =
-          mcp_config.args.length > 0
-            ? Mpak.resolveArgs(mcp_config.args, cacheDir)
+          userArgs.length > 0
+            ? Mpak.resolveArgs(userArgs, cacheDir)
             : ['run', join(cacheDir, entry_point)];
         break;
       }

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { McpbManifest } from '@nimblebrain/mpak-schemas';
@@ -13,6 +12,7 @@ import {
   localBundleNeedsExtract,
   readJsonFromFile,
 } from './helpers.js';
+import { resolvePython } from './python-resolver.js';
 import type { MpakClientConfig } from './types.js';
 
 /**
@@ -38,6 +38,14 @@ export interface MpakOptions {
    * policy.
    */
   maxUncompressedSize?: number;
+  /**
+   * Override the Python interpreter probe used by `type: "python"` bundles.
+   *
+   * Production callers omit this — the resolver spawns the real binary to
+   * read `sys.implementation.cache_tag`. Tests inject a stub so the suite
+   * doesn't depend on which Python is on the runner's PATH.
+   */
+  pythonProbe?: (command: string) => { cacheTag: string; version: string } | null;
 }
 
 /**
@@ -132,6 +140,8 @@ export class Mpak {
   readonly client: MpakClient;
   /** Local bundle cache. */
   readonly bundleCache: MpakBundleCache;
+  /** Optional probe override for `type: "python"` resolution (test seam). */
+  private readonly pythonProbe: MpakOptions["pythonProbe"];
 
   constructor(options?: MpakOptions) {
     // initialize config
@@ -156,6 +166,8 @@ export class Mpak {
       cacheOptions.maxUncompressedSize = options.maxUncompressedSize;
     }
     this.bundleCache = new MpakBundleCache(this.client, cacheOptions);
+
+    this.pythonProbe = options?.pythonProbe;
   }
 
   /**
@@ -391,12 +403,16 @@ export class Mpak {
   /**
    * Resolve the manifest's `server` block into a spawnable command, args, and env.
    *
-   * Handles three server types:
+   * Handles four server types:
    * - **binary** — runs the compiled executable at `entry_point`, chmod'd +x.
    * - **node** — runs `mcp_config.command` (default `"node"`) with `mcp_config.args`,
    *   or falls back to `node <entry_point>` when args are empty.
-   * - **python** — like node, but resolves `python3`/`python` at runtime and
-   *   prepends `<cacheDir>/deps` to `PYTHONPATH` for bundled dependencies.
+   * - **python** — single-probe interpreter resolution via {@link resolvePython}
+   *   (MPAK_PYTHON > manifest command > `python3`), ABI-validated against the
+   *   bundle's compiled extensions and `compatibility.runtimes.python`. Prepends
+   *   `<cacheDir>/deps` to `PYTHONPATH` for bundled dependencies.
+   * - **uv** — invokes uv to provision Python and install deps from
+   *   `pyproject.toml` (default args: `run --directory <cacheDir> <entry_point>`).
    *
    * All `${__dirname}` placeholders in args are replaced with `cacheDir`.
    * All `${user_config.*}` placeholders in env are replaced with gathered user values.
@@ -443,10 +459,25 @@ export class Mpak {
       }
 
       case 'python': {
-        command =
-          mcp_config.command === 'python'
-            ? Mpak.findPythonCommand()
-            : mcp_config.command || Mpak.findPythonCommand();
+        // No candidate-name parade: ABI-validate exactly one interpreter
+        // (MPAK_PYTHON env > manifest command > "python3"). Throws with an
+        // actionable message — including how to set MPAK_PYTHON — when the
+        // chosen interpreter doesn't match the bundle's compiled deps or the
+        // manifest's declared `compatibility.runtimes.python` range.
+        const resolved = resolvePython({
+          cacheDir,
+          manifestCommand: mcp_config.command,
+          declaredRange: manifest.compatibility?.runtimes?.python,
+          env: process.env,
+          ...(this.pythonProbe ? { probe: this.pythonProbe } : {}),
+        });
+        command = resolved.command;
+        // One stderr line at startup so users never have to ask "which Python
+        // is mpak actually running?". Removes the entire class of issue #90
+        // debug sessions.
+        process.stderr.write(
+          `[mpak] python: ${resolved.command} (${resolved.version}, ${resolved.cacheTag}) via ${resolved.source}\n`,
+        );
         args =
           userArgs.length > 0
             ? Mpak.resolveArgs(userArgs, cacheDir)
@@ -519,16 +550,6 @@ export class Mpak {
     return result;
   }
 
-  /**
-   * Find a working Python executable. Tries `python3` first, falls back to `python`.
-   */
-  private static findPythonCommand(): string {
-    const result = spawnSync('python3', ['--version'], { stdio: 'pipe' });
-    if (result.status === 0) {
-      return 'python3';
-    }
-    return 'python';
-  }
 }
 
 /**

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -150,9 +150,9 @@ export class Mpak {
   /** Local bundle cache. */
   readonly bundleCache: MpakBundleCache;
   /** Optional probe override for `type: "python"` resolution (test seam). */
-  private readonly pythonProbe: MpakOptions["pythonProbe"];
+  private readonly pythonProbe: MpakOptions['pythonProbe'];
   /** Optional probe override for `type: "uv"` resolution (test seam). */
-  private readonly uvProbe: MpakOptions["uvProbe"];
+  private readonly uvProbe: MpakOptions['uvProbe'];
 
   constructor(options?: MpakOptions) {
     // initialize config
@@ -516,9 +516,7 @@ export class Mpak {
         });
         command = resolvedUv.command;
         args = resolvedUv.args;
-        process.stderr.write(
-          `[mpak] uv: ${resolvedUv.command} (${resolvedUv.version})\n`,
-        );
+        process.stderr.write(`[mpak] uv: ${resolvedUv.command} (${resolvedUv.version})\n`);
         break;
       }
 
@@ -573,7 +571,6 @@ export class Mpak {
     }
     return result;
   }
-
 }
 
 /**

--- a/packages/sdk-typescript/src/mpakSDK.ts
+++ b/packages/sdk-typescript/src/mpakSDK.ts
@@ -13,6 +13,7 @@ import {
   readJsonFromFile,
 } from './helpers.js';
 import { resolvePython } from './python-resolver.js';
+import { resolveUv } from './uv-resolver.js';
 import type { MpakClientConfig } from './types.js';
 
 /**
@@ -46,6 +47,14 @@ export interface MpakOptions {
    * doesn't depend on which Python is on the runner's PATH.
    */
   pythonProbe?: (command: string) => { cacheTag: string; version: string } | null;
+  /**
+   * Override the `uv --version` probe used by `type: "uv"` bundles.
+   *
+   * Production callers omit this — the resolver spawns the real binary to
+   * confirm uv is installed. Tests inject a stub so the suite doesn't
+   * depend on whether uv is on the runner's PATH.
+   */
+  uvProbe?: (command: string) => { version: string } | null;
 }
 
 /**
@@ -142,6 +151,8 @@ export class Mpak {
   readonly bundleCache: MpakBundleCache;
   /** Optional probe override for `type: "python"` resolution (test seam). */
   private readonly pythonProbe: MpakOptions["pythonProbe"];
+  /** Optional probe override for `type: "uv"` resolution (test seam). */
+  private readonly uvProbe: MpakOptions["uvProbe"];
 
   constructor(options?: MpakOptions) {
     // initialize config
@@ -168,6 +179,7 @@ export class Mpak {
     this.bundleCache = new MpakBundleCache(this.client, cacheOptions);
 
     this.pythonProbe = options?.pythonProbe;
+    this.uvProbe = options?.uvProbe;
   }
 
   /**
@@ -490,11 +502,23 @@ export class Mpak {
       }
 
       case 'uv': {
-        command = mcp_config.command || 'uv';
-        args =
-          userArgs.length > 0
-            ? Mpak.resolveArgs(userArgs, cacheDir)
-            : ['run', join(cacheDir, entry_point)];
+        // Preflight uv before spawning so the failure mode is "install uv"
+        // instead of a raw ENOENT mid-spawn. Default args follow the spec
+        // example (`run --directory <cacheDir> <entry>`) so the invocation
+        // is cwd-independent — embedders that don't honor `server.cwd`
+        // still find pyproject.toml correctly.
+        const resolvedUv = resolveUv({
+          cacheDir,
+          entryPoint: entry_point,
+          manifestCommand: mcp_config.command,
+          userArgs: Mpak.resolveArgs(userArgs, cacheDir),
+          ...(this.uvProbe ? { probe: this.uvProbe } : {}),
+        });
+        command = resolvedUv.command;
+        args = resolvedUv.args;
+        process.stderr.write(
+          `[mpak] uv: ${resolvedUv.command} (${resolvedUv.version})\n`,
+        );
         break;
       }
 

--- a/packages/sdk-typescript/src/python-resolver.ts
+++ b/packages/sdk-typescript/src/python-resolver.ts
@@ -1,0 +1,398 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Required Python ABI inferred from a bundle's vendored extension modules.
+ *
+ * - `tag: "cpython-313"`, `abi3: false` — pinned to one major.minor.
+ * - `tag: "abi3"`, `abi3: true`, `floor: { major: 3, minor: 7 }` — stable ABI;
+ *   any cpython >= floor satisfies it.
+ * - `null` from {@link findRequiredAbi} means a pure-Python bundle (no `.so`/
+ *   `.pyd` files); any interpreter satisfying the manifest's declared range
+ *   will do.
+ */
+export interface RequiredAbi {
+  tag: string;
+  abi3: boolean;
+  floor?: { major: number; minor: number };
+}
+
+/**
+ * Parse the cpython ABI tag from a single compiled-extension filename.
+ *
+ * Recognized shapes (per PEP 425 and the abi3 stable-ABI convention):
+ *   - `<mod>.cpython-313-darwin.so`            → `{ tag: "cpython-313" }`
+ *   - `<mod>.cpython-313-x86_64-linux-gnu.so`  → `{ tag: "cpython-313" }`
+ *   - `<mod>.cpython-3.7-abi3-<plat>.so`       → `{ tag: "abi3", floor: 3.7 }`
+ *   - `<mod>.abi3.so`                          → `{ tag: "abi3", floor: 3.2 }`
+ *
+ * Returns `null` for filenames that don't match any known pattern (e.g.
+ * pure-Python `.py` files, vendor metadata) so the caller can keep scanning.
+ */
+export function parseCpythonTag(filename: string): RequiredAbi | null {
+  // abi3 with explicit floor: cpython-3.7-abi3-<plat>.so
+  const abi3WithFloor = /\.cpython-(\d+)\.(\d+)-abi3[-.]/.exec(filename);
+  if (abi3WithFloor) {
+    return {
+      tag: "abi3",
+      abi3: true,
+      floor: {
+        major: Number(abi3WithFloor[1]),
+        minor: Number(abi3WithFloor[2]),
+      },
+    };
+  }
+  // Bare abi3 (no floor declared in name): historically any 3.2+, but in
+  // practice cpython has only shipped abi3 wheels from 3.7+. Use 3.7 as the
+  // pragmatic floor — narrower than the spec, broader than any modern host.
+  if (/\.abi3\.(so|pyd|dylib)$/.test(filename)) {
+    return { tag: "abi3", abi3: true, floor: { major: 3, minor: 7 } };
+  }
+  // Specific: cpython-XY-... or cpython-XYZ-... (concatenated major+minor)
+  const specific = /\.cpython-(\d{2,3})[-.]/.exec(filename);
+  if (specific) {
+    return { tag: `cpython-${specific[1]}`, abi3: false };
+  }
+  return null;
+}
+
+/**
+ * Walk `<cacheDir>/deps/` and return the first compiled-extension ABI
+ * requirement found. A single specific (`cpython-XYZ`) tag wins over abi3 —
+ * if the bundle ships *any* version-specific extension, the whole bundle is
+ * pinned to that interpreter regardless of what other extensions claim.
+ *
+ * Returns `null` for pure-Python bundles (no `.so`/`.pyd`/`.dylib` found).
+ */
+export function findRequiredAbi(cacheDir: string): RequiredAbi | null {
+  const depsDir = join(cacheDir, "deps");
+  if (!existsSync(depsDir)) return null;
+
+  let abi3Hit: RequiredAbi | null = null;
+
+  // Bounded recursive walk — bundles can nest deps a few levels for
+  // namespace packages, but we cap depth defensively to avoid runaway
+  // traversal on a malformed bundle.
+  const walk = (dir: string, depth: number): RequiredAbi | null => {
+    if (depth > 8) return null;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return null;
+    }
+    for (const name of entries) {
+      const full = join(dir, name);
+      let stat;
+      try {
+        stat = statSync(full);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        const found = walk(full, depth + 1);
+        if (found && !found.abi3) return found;
+        if (found && found.abi3 && !abi3Hit) abi3Hit = found;
+        continue;
+      }
+      if (!/\.(so|pyd|dylib)$/.test(name)) continue;
+      const parsed = parseCpythonTag(name);
+      if (!parsed) continue;
+      if (!parsed.abi3) return parsed;
+      if (!abi3Hit) abi3Hit = parsed;
+    }
+    return null;
+  };
+
+  return walk(depsDir, 0) ?? abi3Hit;
+}
+
+/**
+ * Probe a Python executable for its ABI cache tag and version string.
+ *
+ * Returns `null` if the binary doesn't exist, errors out, or doesn't print
+ * the expected two-line output. We don't distinguish "not found" from
+ * "broken" — both reduce to "this interpreter cannot serve the bundle."
+ */
+export function probeInterpreter(
+  command: string,
+): { cacheTag: string; version: string } | null {
+  const probe = spawnSync(
+    command,
+    [
+      "-c",
+      "import sys; print(sys.implementation.cache_tag); print('.'.join(map(str, sys.version_info[:3])))",
+    ],
+    { stdio: "pipe", timeout: 5_000 },
+  );
+  if (probe.status !== 0) return null;
+  const lines = probe.stdout.toString().trim().split("\n");
+  if (lines.length < 2) return null;
+  const [cacheTag, version] = lines as [string, string];
+  if (!cacheTag || !version) return null;
+  return { cacheTag, version };
+}
+
+/**
+ * Compare a probed cpython tag against the bundle's required ABI.
+ */
+export function abiMatches(probedTag: string, required: RequiredAbi): boolean {
+  if (!required.abi3) {
+    return probedTag === required.tag;
+  }
+  // abi3: probed interpreter must be cpython >= floor.
+  const m = /^cpython-(\d+)$/.exec(probedTag);
+  if (!m) return false;
+  const probedDigits = m[1]!;
+  // `cpython-313` packs major+minor as digits; `cpython-3.7` would split on a
+  // dot, but Python's cache_tag joins them. We treat `313` → 3.13, `37` → 3.7.
+  const major = Number(probedDigits[0]);
+  const minor = Number(probedDigits.slice(1));
+  if (!required.floor) return major === 3;
+  if (major !== required.floor.major) return major > required.floor.major;
+  return minor >= required.floor.minor;
+}
+
+/**
+ * Minimal satisfier for `compatibility.runtimes.python`-style ranges.
+ *
+ * Supported clauses (comma-separated, ANDed): `>=X.Y`, `>X.Y`, `<=X.Y`,
+ * `<X.Y`, `==X.Y` / `=X.Y` / `X.Y` (exact). Patches optional. Whitespace
+ * tolerated. No `^`/`~` — those aren't standard for Python `requires-python`
+ * and we don't want to invent semantics.
+ *
+ * Returns `true` when the version satisfies *all* clauses, `false` when any
+ * clause rejects it, and `true` for an empty/unparseable range (caller should
+ * treat unparseable input as "no constraint" rather than crashing the host).
+ */
+export function satisfiesPythonRange(version: string, range: string): boolean {
+  const v = parseVersion(version);
+  if (!v) return true;
+  const clauses = range.split(",").map((s) => s.trim()).filter(Boolean);
+  if (clauses.length === 0) return true;
+  for (const clause of clauses) {
+    if (!evaluateClause(v, clause)) return false;
+  }
+  return true;
+}
+
+interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseVersion(raw: string): SemVer | null {
+  const m = /^(\d+)\.(\d+)(?:\.(\d+))?/.exec(raw.trim());
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: m[3] ? Number(m[3]) : 0,
+  };
+}
+
+function compareVersions(a: SemVer, b: SemVer): number {
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+function evaluateClause(v: SemVer, clause: string): boolean {
+  const m = /^(>=|<=|>|<|==|=)?\s*(\d+\.\d+(?:\.\d+)?)$/.exec(clause);
+  if (!m) return true; // unparseable clause → don't reject
+  const op = m[1] ?? "==";
+  const target = parseVersion(m[2]!)!;
+  const cmp = compareVersions(v, target);
+  switch (op) {
+    case ">=":
+      return cmp >= 0;
+    case ">":
+      return cmp > 0;
+    case "<=":
+      return cmp <= 0;
+    case "<":
+      return cmp < 0;
+    case "==":
+    case "=":
+      // Exact-on-major.minor when patch wasn't specified in target — treats
+      // `==3.13` as "any 3.13.x".
+      if (!/\.\d+\.\d+/.test(m[2]!)) {
+        return v.major === target.major && v.minor === target.minor;
+      }
+      return cmp === 0;
+    default:
+      return true;
+  }
+}
+
+/**
+ * Resolution input.
+ */
+export interface ResolvePythonOptions {
+  /** Bundle cache directory (contains `deps/`). */
+  cacheDir: string;
+  /** `mcp_config.command` from the manifest, if declared. */
+  manifestCommand: string | undefined;
+  /** `compatibility.runtimes.python` range from the manifest, if declared. */
+  declaredRange: string | undefined;
+  /**
+   * Process env, used to read `MPAK_PYTHON`. Caller passes `process.env` in
+   * production; tests inject a synthetic record.
+   */
+  env: NodeJS.ProcessEnv;
+  /**
+   * Override the interpreter probe. Production callers omit this and the
+   * resolver spawns the real binary. Tests inject a stub so the suite
+   * doesn't depend on which Python happens to be on the test runner.
+   */
+  probe?: (command: string) => { cacheTag: string; version: string } | null;
+}
+
+/**
+ * Resolution result — the spawnable command plus diagnostics for the caller
+ * to log.
+ */
+export interface ResolvedPython {
+  command: string;
+  cacheTag: string;
+  version: string;
+  source: "MPAK_PYTHON" | "manifest" | "default";
+}
+
+/**
+ * One probe, no candidate parade.
+ *
+ * Resolution order: `MPAK_PYTHON` env var → `mcp_config.command` →
+ * literal `"python3"`. We pick exactly one command, probe it once, and
+ * either return it (on ABI + range match) or throw with an actionable
+ * message. The contract is "tell me which Python to use; if it doesn't fit,
+ * I'll explain why and stop."
+ */
+export function resolvePython(options: ResolvePythonOptions): ResolvedPython {
+  const { cacheDir, manifestCommand, declaredRange, env, probe = probeInterpreter } = options;
+
+  let command: string;
+  let source: ResolvedPython["source"];
+  if (env["MPAK_PYTHON"] && env["MPAK_PYTHON"].trim().length > 0) {
+    command = env["MPAK_PYTHON"];
+    source = "MPAK_PYTHON";
+  } else if (manifestCommand && manifestCommand.length > 0) {
+    command = manifestCommand;
+    source = "manifest";
+  } else {
+    command = "python3";
+    source = "default";
+  }
+
+  const probed = probe(command);
+  if (!probed) {
+    throw new PythonResolutionError(
+      formatNotFoundMessage(command, source, cacheDir),
+    );
+  }
+
+  const required = findRequiredAbi(cacheDir);
+  if (required && !abiMatches(probed.cacheTag, required)) {
+    throw new PythonResolutionError(
+      formatAbiMismatchMessage(command, source, probed, required),
+    );
+  }
+
+  if (declaredRange && !satisfiesPythonRange(probed.version, declaredRange)) {
+    throw new PythonResolutionError(
+      formatRangeMismatchMessage(command, source, probed, declaredRange),
+    );
+  }
+
+  return { command, cacheTag: probed.cacheTag, version: probed.version, source };
+}
+
+/**
+ * Surfaced when the resolver cannot pick a Python interpreter that runs the
+ * bundle. Callers translate this to a CLI-friendly error.
+ */
+export class PythonResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PythonResolutionError";
+  }
+}
+
+function formatNotFoundMessage(
+  command: string,
+  source: ResolvedPython["source"],
+  _cacheDir: string,
+): string {
+  const origin =
+    source === "MPAK_PYTHON"
+      ? "MPAK_PYTHON env var"
+      : source === "manifest"
+        ? "bundle manifest"
+        : "default";
+  return [
+    `Python interpreter '${command}' (from ${origin}) is not runnable.`,
+    `  Set MPAK_PYTHON to a working interpreter:`,
+    `    export MPAK_PYTHON=$(which python3)`,
+    `  Or install Python: https://www.python.org/downloads/`,
+  ].join("\n");
+}
+
+function formatAbiMismatchMessage(
+  command: string,
+  source: ResolvedPython["source"],
+  probed: { cacheTag: string; version: string },
+  required: RequiredAbi,
+): string {
+  const requiredHuman = required.abi3
+    ? `Python ${required.floor!.major}.${required.floor!.minor}+ (stable ABI)`
+    : `Python ${cpythonTagToHuman(required.tag)} (${required.tag})`;
+  const originLabel =
+    source === "MPAK_PYTHON"
+      ? "MPAK_PYTHON"
+      : source === "manifest"
+        ? "manifest mcp_config.command"
+        : "default 'python3'";
+  return [
+    `Bundle requires ${requiredHuman}.`,
+    `  Found: ${command} = ${probed.version} (${probed.cacheTag}), via ${originLabel}.`,
+    `  Fix: export MPAK_PYTHON=$(which ${suggestBinary(required)})`,
+    `  Or install: pyenv install ${suggestVersion(required)} | brew install python@${suggestVersion(required)} | uv python install ${suggestVersion(required)}`,
+  ].join("\n");
+}
+
+function formatRangeMismatchMessage(
+  command: string,
+  source: ResolvedPython["source"],
+  probed: { cacheTag: string; version: string },
+  range: string,
+): string {
+  const originLabel =
+    source === "MPAK_PYTHON"
+      ? "MPAK_PYTHON"
+      : source === "manifest"
+        ? "manifest mcp_config.command"
+        : "default 'python3'";
+  return [
+    `Bundle declares compatibility.runtimes.python: '${range}'.`,
+    `  Found: ${command} = ${probed.version}, via ${originLabel}.`,
+    `  Fix: install a satisfying Python and set MPAK_PYTHON to its path.`,
+  ].join("\n");
+}
+
+function cpythonTagToHuman(tag: string): string {
+  const m = /^cpython-(\d+)$/.exec(tag);
+  if (!m) return tag;
+  const digits = m[1]!;
+  return `${digits[0]}.${digits.slice(1)}`;
+}
+
+function suggestVersion(required: RequiredAbi): string {
+  if (required.abi3 && required.floor) {
+    return `${required.floor.major}.${required.floor.minor}`;
+  }
+  return cpythonTagToHuman(required.tag);
+}
+
+function suggestBinary(required: RequiredAbi): string {
+  return `python${suggestVersion(required)}`;
+}

--- a/packages/sdk-typescript/src/python-resolver.ts
+++ b/packages/sdk-typescript/src/python-resolver.ts
@@ -1,6 +1,6 @@
-import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
 
 /**
  * Required Python ABI inferred from a bundle's vendored extension modules.
@@ -35,7 +35,7 @@ export function parseCpythonTag(filename: string): RequiredAbi | null {
   const abi3WithFloor = /\.cpython-(\d+)\.(\d+)-abi3[-.]/.exec(filename);
   if (abi3WithFloor) {
     return {
-      tag: "abi3",
+      tag: 'abi3',
       abi3: true,
       floor: {
         major: Number(abi3WithFloor[1]),
@@ -47,7 +47,7 @@ export function parseCpythonTag(filename: string): RequiredAbi | null {
   // practice cpython has only shipped abi3 wheels from 3.7+. Use 3.7 as the
   // pragmatic floor — narrower than the spec, broader than any modern host.
   if (/\.abi3\.(so|pyd|dylib)$/.test(filename)) {
-    return { tag: "abi3", abi3: true, floor: { major: 3, minor: 7 } };
+    return { tag: 'abi3', abi3: true, floor: { major: 3, minor: 7 } };
   }
   // Specific: cpython-XY-... or cpython-XYZ-... (concatenated major+minor)
   const specific = /\.cpython-(\d{2,3})[-.]/.exec(filename);
@@ -66,7 +66,7 @@ export function parseCpythonTag(filename: string): RequiredAbi | null {
  * Returns `null` for pure-Python bundles (no `.so`/`.pyd`/`.dylib` found).
  */
 export function findRequiredAbi(cacheDir: string): RequiredAbi | null {
-  const depsDir = join(cacheDir, "deps");
+  const depsDir = join(cacheDir, 'deps');
   if (!existsSync(depsDir)) return null;
 
   let abi3Hit: RequiredAbi | null = null;
@@ -115,19 +115,17 @@ export function findRequiredAbi(cacheDir: string): RequiredAbi | null {
  * the expected two-line output. We don't distinguish "not found" from
  * "broken" — both reduce to "this interpreter cannot serve the bundle."
  */
-export function probeInterpreter(
-  command: string,
-): { cacheTag: string; version: string } | null {
+export function probeInterpreter(command: string): { cacheTag: string; version: string } | null {
   const probe = spawnSync(
     command,
     [
-      "-c",
+      '-c',
       "import sys; print(sys.implementation.cache_tag); print('.'.join(map(str, sys.version_info[:3])))",
     ],
-    { stdio: "pipe", timeout: 5_000 },
+    { stdio: 'pipe', timeout: 5_000 },
   );
   if (probe.status !== 0) return null;
-  const lines = probe.stdout.toString().trim().split("\n");
+  const lines = probe.stdout.toString().trim().split('\n');
   if (lines.length < 2) return null;
   const [cacheTag, version] = lines as [string, string];
   if (!cacheTag || !version) return null;
@@ -169,7 +167,10 @@ export function abiMatches(probedTag: string, required: RequiredAbi): boolean {
 export function satisfiesPythonRange(version: string, range: string): boolean {
   const v = parseVersion(version);
   if (!v) return true;
-  const clauses = range.split(",").map((s) => s.trim()).filter(Boolean);
+  const clauses = range
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
   if (clauses.length === 0) return true;
   for (const clause of clauses) {
     if (!evaluateClause(v, clause)) return false;
@@ -200,20 +201,20 @@ function compareVersions(a: SemVer, b: SemVer): number {
 function evaluateClause(v: SemVer, clause: string): boolean {
   const m = /^(>=|<=|>|<|==|=)?\s*(\d+\.\d+(?:\.\d+)?)$/.exec(clause);
   if (!m) return true; // unparseable clause → don't reject
-  const op = m[1] ?? "==";
+  const op = m[1] ?? '==';
   const target = parseVersion(m[2]!)!;
   const cmp = compareVersions(v, target);
   switch (op) {
-    case ">=":
+    case '>=':
       return cmp >= 0;
-    case ">":
+    case '>':
       return cmp > 0;
-    case "<=":
+    case '<=':
       return cmp <= 0;
-    case "<":
+    case '<':
       return cmp < 0;
-    case "==":
-    case "=":
+    case '==':
+    case '=':
       // Exact-on-major.minor when patch wasn't specified in target — treats
       // `==3.13` as "any 3.13.x".
       if (!/\.\d+\.\d+/.test(m[2]!)) {
@@ -256,7 +257,7 @@ export interface ResolvedPython {
   command: string;
   cacheTag: string;
   version: string;
-  source: "MPAK_PYTHON" | "manifest" | "default";
+  source: 'MPAK_PYTHON' | 'manifest' | 'default';
 }
 
 /**
@@ -272,30 +273,26 @@ export function resolvePython(options: ResolvePythonOptions): ResolvedPython {
   const { cacheDir, manifestCommand, declaredRange, env, probe = probeInterpreter } = options;
 
   let command: string;
-  let source: ResolvedPython["source"];
-  if (env["MPAK_PYTHON"] && env["MPAK_PYTHON"].trim().length > 0) {
-    command = env["MPAK_PYTHON"];
-    source = "MPAK_PYTHON";
+  let source: ResolvedPython['source'];
+  if (env['MPAK_PYTHON'] && env['MPAK_PYTHON'].trim().length > 0) {
+    command = env['MPAK_PYTHON'];
+    source = 'MPAK_PYTHON';
   } else if (manifestCommand && manifestCommand.length > 0) {
     command = manifestCommand;
-    source = "manifest";
+    source = 'manifest';
   } else {
-    command = "python3";
-    source = "default";
+    command = 'python3';
+    source = 'default';
   }
 
   const probed = probe(command);
   if (!probed) {
-    throw new PythonResolutionError(
-      formatNotFoundMessage(command, source, cacheDir),
-    );
+    throw new PythonResolutionError(formatNotFoundMessage(command, source, cacheDir));
   }
 
   const required = findRequiredAbi(cacheDir);
   if (required && !abiMatches(probed.cacheTag, required)) {
-    throw new PythonResolutionError(
-      formatAbiMismatchMessage(command, source, probed, required),
-    );
+    throw new PythonResolutionError(formatAbiMismatchMessage(command, source, probed, required));
   }
 
   if (declaredRange && !satisfiesPythonRange(probed.version, declaredRange)) {
@@ -314,32 +311,32 @@ export function resolvePython(options: ResolvePythonOptions): ResolvedPython {
 export class PythonResolutionError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "PythonResolutionError";
+    this.name = 'PythonResolutionError';
   }
 }
 
 function formatNotFoundMessage(
   command: string,
-  source: ResolvedPython["source"],
+  source: ResolvedPython['source'],
   _cacheDir: string,
 ): string {
   const origin =
-    source === "MPAK_PYTHON"
-      ? "MPAK_PYTHON env var"
-      : source === "manifest"
-        ? "bundle manifest"
-        : "default";
+    source === 'MPAK_PYTHON'
+      ? 'MPAK_PYTHON env var'
+      : source === 'manifest'
+        ? 'bundle manifest'
+        : 'default';
   return [
     `Python interpreter '${command}' (from ${origin}) is not runnable.`,
     `  Set MPAK_PYTHON to a working interpreter:`,
     `    export MPAK_PYTHON=$(which python3)`,
     `  Or install Python: https://www.python.org/downloads/`,
-  ].join("\n");
+  ].join('\n');
 }
 
 function formatAbiMismatchMessage(
   command: string,
-  source: ResolvedPython["source"],
+  source: ResolvedPython['source'],
   probed: { cacheTag: string; version: string },
   required: RequiredAbi,
 ): string {
@@ -347,36 +344,36 @@ function formatAbiMismatchMessage(
     ? `Python ${required.floor!.major}.${required.floor!.minor}+ (stable ABI)`
     : `Python ${cpythonTagToHuman(required.tag)} (${required.tag})`;
   const originLabel =
-    source === "MPAK_PYTHON"
-      ? "MPAK_PYTHON"
-      : source === "manifest"
-        ? "manifest mcp_config.command"
+    source === 'MPAK_PYTHON'
+      ? 'MPAK_PYTHON'
+      : source === 'manifest'
+        ? 'manifest mcp_config.command'
         : "default 'python3'";
   return [
     `Bundle requires ${requiredHuman}.`,
     `  Found: ${command} = ${probed.version} (${probed.cacheTag}), via ${originLabel}.`,
     `  Fix: export MPAK_PYTHON=$(which ${suggestBinary(required)})`,
     `  Or install: pyenv install ${suggestVersion(required)} | brew install python@${suggestVersion(required)} | uv python install ${suggestVersion(required)}`,
-  ].join("\n");
+  ].join('\n');
 }
 
 function formatRangeMismatchMessage(
   command: string,
-  source: ResolvedPython["source"],
+  source: ResolvedPython['source'],
   probed: { cacheTag: string; version: string },
   range: string,
 ): string {
   const originLabel =
-    source === "MPAK_PYTHON"
-      ? "MPAK_PYTHON"
-      : source === "manifest"
-        ? "manifest mcp_config.command"
+    source === 'MPAK_PYTHON'
+      ? 'MPAK_PYTHON'
+      : source === 'manifest'
+        ? 'manifest mcp_config.command'
         : "default 'python3'";
   return [
     `Bundle declares compatibility.runtimes.python: '${range}'.`,
     `  Found: ${command} = ${probed.version}, via ${originLabel}.`,
     `  Fix: install a satisfying Python and set MPAK_PYTHON to its path.`,
-  ].join("\n");
+  ].join('\n');
 }
 
 function cpythonTagToHuman(tag: string): string {

--- a/packages/sdk-typescript/src/uv-resolver.ts
+++ b/packages/sdk-typescript/src/uv-resolver.ts
@@ -1,0 +1,99 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Probe `uv` (or any uv-compatible binary path) for its version.
+ *
+ * Returns `null` if the binary doesn't exist or doesn't respond to
+ * `--version`. We don't distinguish "not installed" from "broken" — both
+ * collapse to "this uv cannot serve the bundle."
+ */
+export function probeUv(command: string): { version: string } | null {
+  const probe = spawnSync(command, ["--version"], {
+    stdio: "pipe",
+    timeout: 5_000,
+  });
+  if (probe.status !== 0) return null;
+  const out = probe.stdout.toString().trim();
+  // `uv --version` prints e.g. "uv 0.4.22 (3f6f4f9 2024-10-17)" — peel off
+  // the leading word and take the version token. Fall back to the full
+  // string if the format ever changes; the caller only uses this for log
+  // output, not parsing.
+  const m = /\b(\d+\.\d+\.\d+\S*)/.exec(out);
+  return { version: m ? m[1]! : out };
+}
+
+/**
+ * Surfaced when uv isn't reachable on the host.
+ */
+export class UvResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UvResolutionError";
+  }
+}
+
+export interface ResolveUvOptions {
+  /** Bundle cache directory — passed to `uv run --directory`. */
+  cacheDir: string;
+  /** Bundle entry point (relative to cacheDir). */
+  entryPoint: string;
+  /** `mcp_config.command` from the manifest. Defaults to `"uv"`. */
+  manifestCommand: string | undefined;
+  /**
+   * Manifest-supplied args, post-substitution. When non-empty the resolver
+   * defers to them; when empty the resolver supplies the spec-canonical
+   * `run --directory <cacheDir> <entry_point>` form.
+   */
+  userArgs: string[];
+  /**
+   * Probe override for tests. Production callers omit this and the resolver
+   * spawns the real binary.
+   */
+  probe?: (command: string) => { version: string } | null;
+}
+
+export interface ResolvedUv {
+  command: string;
+  args: string[];
+  version: string;
+}
+
+/**
+ * Resolve the `uv` invocation for a `type: "uv"` bundle.
+ *
+ * Two responsibilities:
+ *
+ *   1. **Preflight uv.** If the chosen binary isn't reachable, throw a clear
+ *      error with install instructions. Without this, the user sees a raw
+ *      ENOENT mid-spawn and has to know that "uv" is the missing piece.
+ *
+ *   2. **Default args to the spec-canonical form.** When the manifest doesn't
+ *      provide its own args, default to
+ *      `run --directory <cacheDir> <entry_point>` — matching the upstream
+ *      hello-world-uv example. The `--directory` flag makes the invocation
+ *      cwd-independent so embedders that don't honor `server.cwd` still find
+ *      `pyproject.toml` correctly.
+ */
+export function resolveUv(options: ResolveUvOptions): ResolvedUv {
+  const { cacheDir, entryPoint, manifestCommand, userArgs, probe = probeUv } = options;
+
+  const command = manifestCommand && manifestCommand.length > 0 ? manifestCommand : "uv";
+
+  const probed = probe(command);
+  if (!probed) {
+    throw new UvResolutionError(
+      [
+        `\`${command}\` is required to run this bundle but is not on PATH.`,
+        `  Install uv:`,
+        `    macOS / Linux: curl -LsSf https://astral.sh/uv/install.sh | sh`,
+        `    Windows:       irm https://astral.sh/uv/install.ps1 | iex`,
+        `  Docs: https://docs.astral.sh/uv/`,
+      ].join("\n"),
+    );
+  }
+
+  const args =
+    userArgs.length > 0 ? userArgs : ["run", "--directory", cacheDir, entryPoint];
+
+  return { command, args, version: probed.version };
+}

--- a/packages/sdk-typescript/src/uv-resolver.ts
+++ b/packages/sdk-typescript/src/uv-resolver.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync } from 'node:child_process';
 
 /**
  * Probe `uv` (or any uv-compatible binary path) for its version.
@@ -8,8 +8,8 @@ import { spawnSync } from "node:child_process";
  * collapse to "this uv cannot serve the bundle."
  */
 export function probeUv(command: string): { version: string } | null {
-  const probe = spawnSync(command, ["--version"], {
-    stdio: "pipe",
+  const probe = spawnSync(command, ['--version'], {
+    stdio: 'pipe',
     timeout: 5_000,
   });
   if (probe.status !== 0) return null;
@@ -28,7 +28,7 @@ export function probeUv(command: string): { version: string } | null {
 export class UvResolutionError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "UvResolutionError";
+    this.name = 'UvResolutionError';
   }
 }
 
@@ -77,7 +77,7 @@ export interface ResolvedUv {
 export function resolveUv(options: ResolveUvOptions): ResolvedUv {
   const { cacheDir, entryPoint, manifestCommand, userArgs, probe = probeUv } = options;
 
-  const command = manifestCommand && manifestCommand.length > 0 ? manifestCommand : "uv";
+  const command = manifestCommand && manifestCommand.length > 0 ? manifestCommand : 'uv';
 
   const probed = probe(command);
   if (!probed) {
@@ -88,12 +88,11 @@ export function resolveUv(options: ResolveUvOptions): ResolvedUv {
         `    macOS / Linux: curl -LsSf https://astral.sh/uv/install.sh | sh`,
         `    Windows:       irm https://astral.sh/uv/install.ps1 | iex`,
         `  Docs: https://docs.astral.sh/uv/`,
-      ].join("\n"),
+      ].join('\n'),
     );
   }
 
-  const args =
-    userArgs.length > 0 ? userArgs : ["run", "--directory", cacheDir, entryPoint];
+  const args = userArgs.length > 0 ? userArgs : ['run', '--directory', cacheDir, entryPoint];
 
   return { command, args, version: probed.version };
 }

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -251,10 +251,14 @@ describe('Mpak facade', () => {
 
     function setupSdk(
       manifest: McpbManifest | null = nodeManifest,
-      opts: { pythonProbe?: (cmd: string) => { cacheTag: string; version: string } | null } = {},
+      opts: {
+        pythonProbe?: (cmd: string) => { cacheTag: string; version: string } | null;
+        uvProbe?: (cmd: string) => { version: string } | null;
+      } = {},
     ) {
       const sdkOpts: ConstructorParameters<typeof Mpak>[0] = { mpakHome: testDir };
       if (opts.pythonProbe) sdkOpts.pythonProbe = opts.pythonProbe;
+      if (opts.uvProbe) sdkOpts.uvProbe = opts.uvProbe;
       const sdk = new Mpak(sdkOpts);
       const cacheDir = join(testDir, 'cache', 'scope-echo');
 
@@ -340,6 +344,49 @@ describe('Mpak facade', () => {
 
       expect(result.command).toBe(join(cacheDir, 'server'));
       expect(result.args).toEqual(['--port', '3000']);
+    });
+
+    it('resolves a uv server with the spec-canonical default args', async () => {
+      // Mirrors `examples/hello-world-uv/manifest.json` upstream: the bundle
+      // omits args, the resolver supplies `run --directory <cacheDir> <entry>`.
+      const uvManifest: McpbManifest = {
+        ...nodeManifest,
+        server: {
+          type: 'uv',
+          entry_point: 'src/server.py',
+        },
+        compatibility: { runtimes: { python: '>=3.13' } },
+      };
+      const { sdk, cacheDir } = setupSdk(uvManifest, {
+        uvProbe: () => ({ version: '0.4.22' }),
+      });
+
+      const result = await sdk.prepareServer({ name: '@scope/echo' });
+
+      expect(result.command).toBe('uv');
+      expect(result.args).toEqual([
+        'run',
+        '--directory',
+        cacheDir,
+        'src/server.py',
+      ]);
+    });
+
+    it('throws when uv mode is requested but uv is not installed', async () => {
+      const uvManifest: McpbManifest = {
+        ...nodeManifest,
+        server: {
+          type: 'uv',
+          entry_point: 'src/server.py',
+        },
+      };
+      const { sdk } = setupSdk(uvManifest, {
+        uvProbe: () => null,
+      });
+
+      await expect(sdk.prepareServer({ name: '@scope/echo' })).rejects.toThrow(
+        /not on PATH/,
+      );
     });
 
     it('passes version from spec to loadBundle', async () => {

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -249,8 +249,13 @@ describe('Mpak facade', () => {
       },
     };
 
-    function setupSdk(manifest: McpbManifest | null = nodeManifest) {
-      const sdk = new Mpak({ mpakHome: testDir });
+    function setupSdk(
+      manifest: McpbManifest | null = nodeManifest,
+      opts: { pythonProbe?: (cmd: string) => { cacheTag: string; version: string } | null } = {},
+    ) {
+      const sdkOpts: ConstructorParameters<typeof Mpak>[0] = { mpakHome: testDir };
+      if (opts.pythonProbe) sdkOpts.pythonProbe = opts.pythonProbe;
+      const sdk = new Mpak(sdkOpts);
       const cacheDir = join(testDir, 'cache', 'scope-echo');
 
       vi.spyOn(sdk.bundleCache, 'loadBundle').mockResolvedValue({
@@ -290,7 +295,7 @@ describe('Mpak facade', () => {
       expect(result.args).toEqual([join(cacheDir, 'index.js')]);
     });
 
-    it('resolves a python server', async () => {
+    it('resolves a python server, honoring the manifest command verbatim (issue #90)', async () => {
       const pythonManifest: McpbManifest = {
         ...nodeManifest,
         server: {
@@ -299,11 +304,23 @@ describe('Mpak facade', () => {
           mcp_config: { command: 'python', args: ['${__dirname}/main.py'], env: {} },
         },
       };
-      const { sdk, cacheDir } = setupSdk(pythonManifest);
+      const { sdk, cacheDir } = setupSdk(pythonManifest, {
+        // No `deps/` in the test fixture → ABI check no-ops; the probe still
+        // has to return *something* so resolvePython can confirm the chosen
+        // interpreter is runnable.
+        pythonProbe: (cmd) => {
+          // Pin the assertion below: whatever `cmd` the manifest declared is
+          // exactly what reaches the probe. No silent rewrite to 'python3'.
+          expect(cmd).toBe('python');
+          return { cacheTag: 'cpython-313', version: '3.13.0' };
+        },
+      });
 
       const result = await sdk.prepareServer({ name: '@scope/echo' });
 
-      expect(['python', 'python3']).toContain(result.command);
+      // Manifest said `python` — resolver must return `python`, not 'python3'.
+      // This pins the issue #90 fix.
+      expect(result.command).toBe('python');
       expect(result.args).toEqual([`${cacheDir}/main.py`]);
       expect(result.env['PYTHONPATH']).toContain(join(cacheDir, 'deps'));
     });
@@ -951,7 +968,7 @@ describe('Mpak facade', () => {
       );
     });
 
-    it('resolves a python server from local bundle', async () => {
+    it('resolves a python server from local bundle, honoring the manifest command (issue #90)', async () => {
       const pythonManifest: McpbManifest = {
         ...nodeManifest,
         server: {
@@ -960,12 +977,15 @@ describe('Mpak facade', () => {
           mcp_config: { command: 'python', args: ['${__dirname}/main.py'], env: {} },
         },
       };
-      const sdk = new Mpak({ mpakHome: testDir });
+      const sdk = new Mpak({
+        mpakHome: testDir,
+        pythonProbe: () => ({ cacheTag: 'cpython-313', version: '3.13.0' }),
+      });
       const mcpbPath = createMcpbBundle(testDir, pythonManifest);
 
       const result = await sdk.prepareServer({ local: mcpbPath });
 
-      expect(['python', 'python3']).toContain(result.command);
+      expect(result.command).toBe('python');
       expect(result.args).toEqual([`${result.cwd}/main.py`]);
       expect(result.env['PYTHONPATH']).toContain(join(result.cwd, 'deps'));
     });

--- a/packages/sdk-typescript/tests/mpak.test.ts
+++ b/packages/sdk-typescript/tests/mpak.test.ts
@@ -364,12 +364,7 @@ describe('Mpak facade', () => {
       const result = await sdk.prepareServer({ name: '@scope/echo' });
 
       expect(result.command).toBe('uv');
-      expect(result.args).toEqual([
-        'run',
-        '--directory',
-        cacheDir,
-        'src/server.py',
-      ]);
+      expect(result.args).toEqual(['run', '--directory', cacheDir, 'src/server.py']);
     });
 
     it('throws when uv mode is requested but uv is not installed', async () => {
@@ -384,9 +379,7 @@ describe('Mpak facade', () => {
         uvProbe: () => null,
       });
 
-      await expect(sdk.prepareServer({ name: '@scope/echo' })).rejects.toThrow(
-        /not on PATH/,
-      );
+      await expect(sdk.prepareServer({ name: '@scope/echo' })).rejects.toThrow(/not on PATH/);
     });
 
     it('passes version from spec to loadBundle', async () => {

--- a/packages/sdk-typescript/tests/python-resolver.test.ts
+++ b/packages/sdk-typescript/tests/python-resolver.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   abiMatches,
@@ -10,188 +10,186 @@ import {
   PythonResolutionError,
   resolvePython,
   satisfiesPythonRange,
-} from "../src/python-resolver.js";
+} from '../src/python-resolver.js';
 
-describe("parseCpythonTag", () => {
-  it("recognizes the canonical specific cpython tag", () => {
-    expect(parseCpythonTag("rpds.cpython-313-darwin.so")).toEqual({
-      tag: "cpython-313",
+describe('parseCpythonTag', () => {
+  it('recognizes the canonical specific cpython tag', () => {
+    expect(parseCpythonTag('rpds.cpython-313-darwin.so')).toEqual({
+      tag: 'cpython-313',
       abi3: false,
     });
   });
 
-  it("recognizes a Linux extension with arch + libc in the platform tag", () => {
-    expect(parseCpythonTag("_pydantic_core.cpython-311-x86_64-linux-gnu.so")).toEqual({
-      tag: "cpython-311",
+  it('recognizes a Linux extension with arch + libc in the platform tag', () => {
+    expect(parseCpythonTag('_pydantic_core.cpython-311-x86_64-linux-gnu.so')).toEqual({
+      tag: 'cpython-311',
       abi3: false,
     });
   });
 
-  it("recognizes Windows .pyd extensions", () => {
-    expect(parseCpythonTag("rpds.cpython-313-win_amd64.pyd")).toEqual({
-      tag: "cpython-313",
+  it('recognizes Windows .pyd extensions', () => {
+    expect(parseCpythonTag('rpds.cpython-313-win_amd64.pyd')).toEqual({
+      tag: 'cpython-313',
       abi3: false,
     });
   });
 
-  it("recognizes abi3 with explicit floor", () => {
-    expect(
-      parseCpythonTag("_brotli.cpython-3.7-abi3-x86_64-linux-gnu.so"),
-    ).toEqual({
-      tag: "abi3",
+  it('recognizes abi3 with explicit floor', () => {
+    expect(parseCpythonTag('_brotli.cpython-3.7-abi3-x86_64-linux-gnu.so')).toEqual({
+      tag: 'abi3',
       abi3: true,
       floor: { major: 3, minor: 7 },
     });
   });
 
-  it("recognizes bare abi3 with implicit 3.7 floor", () => {
-    expect(parseCpythonTag("_lib.abi3.so")).toEqual({
-      tag: "abi3",
+  it('recognizes bare abi3 with implicit 3.7 floor', () => {
+    expect(parseCpythonTag('_lib.abi3.so')).toEqual({
+      tag: 'abi3',
       abi3: true,
       floor: { major: 3, minor: 7 },
     });
   });
 
-  it("returns null for non-extension files", () => {
-    expect(parseCpythonTag("module.py")).toBeNull();
-    expect(parseCpythonTag("README.md")).toBeNull();
+  it('returns null for non-extension files', () => {
+    expect(parseCpythonTag('module.py')).toBeNull();
+    expect(parseCpythonTag('README.md')).toBeNull();
   });
 });
 
-describe("findRequiredAbi", () => {
+describe('findRequiredAbi', () => {
   let testDir: string;
 
   beforeEach(() => {
-    testDir = mkdtempSync(join(tmpdir(), "mpak-python-resolver-"));
+    testDir = mkdtempSync(join(tmpdir(), 'mpak-python-resolver-'));
   });
 
   afterEach(() => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it("returns null when there is no deps/ directory (pure-Python bundle)", () => {
+  it('returns null when there is no deps/ directory (pure-Python bundle)', () => {
     expect(findRequiredAbi(testDir)).toBeNull();
   });
 
-  it("returns null when deps/ has no compiled extensions", () => {
-    mkdirSync(join(testDir, "deps", "pure_pkg"), { recursive: true });
-    writeFileSync(join(testDir, "deps", "pure_pkg", "__init__.py"), "");
+  it('returns null when deps/ has no compiled extensions', () => {
+    mkdirSync(join(testDir, 'deps', 'pure_pkg'), { recursive: true });
+    writeFileSync(join(testDir, 'deps', 'pure_pkg', '__init__.py'), '');
     expect(findRequiredAbi(testDir)).toBeNull();
   });
 
-  it("finds the cpython tag of a vendored compiled extension", () => {
-    mkdirSync(join(testDir, "deps", "rpds"), { recursive: true });
-    writeFileSync(join(testDir, "deps", "rpds", "rpds.cpython-313-darwin.so"), "");
-    expect(findRequiredAbi(testDir)).toEqual({ tag: "cpython-313", abi3: false });
+  it('finds the cpython tag of a vendored compiled extension', () => {
+    mkdirSync(join(testDir, 'deps', 'rpds'), { recursive: true });
+    writeFileSync(join(testDir, 'deps', 'rpds', 'rpds.cpython-313-darwin.so'), '');
+    expect(findRequiredAbi(testDir)).toEqual({ tag: 'cpython-313', abi3: false });
   });
 
-  it("prefers a specific cpython tag over an abi3 tag in the same bundle", () => {
+  it('prefers a specific cpython tag over an abi3 tag in the same bundle', () => {
     // A bundle that mixes a version-pinned extension (e.g. pydantic_core) with
     // an abi3-only extension is pinned by the version-specific one, since the
     // host interpreter has to satisfy both.
-    mkdirSync(join(testDir, "deps", "a"), { recursive: true });
-    mkdirSync(join(testDir, "deps", "b"), { recursive: true });
-    writeFileSync(join(testDir, "deps", "a", "specific.cpython-313-darwin.so"), "");
-    writeFileSync(join(testDir, "deps", "b", "stable.abi3.so"), "");
-    expect(findRequiredAbi(testDir)).toEqual({ tag: "cpython-313", abi3: false });
+    mkdirSync(join(testDir, 'deps', 'a'), { recursive: true });
+    mkdirSync(join(testDir, 'deps', 'b'), { recursive: true });
+    writeFileSync(join(testDir, 'deps', 'a', 'specific.cpython-313-darwin.so'), '');
+    writeFileSync(join(testDir, 'deps', 'b', 'stable.abi3.so'), '');
+    expect(findRequiredAbi(testDir)).toEqual({ tag: 'cpython-313', abi3: false });
   });
 
-  it("returns abi3 when the bundle ships only stable-ABI extensions", () => {
-    mkdirSync(join(testDir, "deps", "c"), { recursive: true });
-    writeFileSync(join(testDir, "deps", "c", "stable.abi3.so"), "");
+  it('returns abi3 when the bundle ships only stable-ABI extensions', () => {
+    mkdirSync(join(testDir, 'deps', 'c'), { recursive: true });
+    writeFileSync(join(testDir, 'deps', 'c', 'stable.abi3.so'), '');
     expect(findRequiredAbi(testDir)).toEqual({
-      tag: "abi3",
+      tag: 'abi3',
       abi3: true,
       floor: { major: 3, minor: 7 },
     });
   });
 });
 
-describe("abiMatches", () => {
-  it("requires exact match for version-specific cpython tags", () => {
-    expect(abiMatches("cpython-313", { tag: "cpython-313", abi3: false })).toBe(true);
-    expect(abiMatches("cpython-311", { tag: "cpython-313", abi3: false })).toBe(false);
+describe('abiMatches', () => {
+  it('requires exact match for version-specific cpython tags', () => {
+    expect(abiMatches('cpython-313', { tag: 'cpython-313', abi3: false })).toBe(true);
+    expect(abiMatches('cpython-311', { tag: 'cpython-313', abi3: false })).toBe(false);
   });
 
-  it("accepts any cpython >= floor for abi3", () => {
-    const required = { tag: "abi3", abi3: true, floor: { major: 3, minor: 7 } };
-    expect(abiMatches("cpython-313", required)).toBe(true);
-    expect(abiMatches("cpython-37", required)).toBe(true);
-    expect(abiMatches("cpython-36", required)).toBe(false);
+  it('accepts any cpython >= floor for abi3', () => {
+    const required = { tag: 'abi3', abi3: true, floor: { major: 3, minor: 7 } };
+    expect(abiMatches('cpython-313', required)).toBe(true);
+    expect(abiMatches('cpython-37', required)).toBe(true);
+    expect(abiMatches('cpython-36', required)).toBe(false);
   });
 
-  it("rejects non-cpython probed tags", () => {
-    expect(abiMatches("pypy3", { tag: "cpython-313", abi3: false })).toBe(false);
+  it('rejects non-cpython probed tags', () => {
+    expect(abiMatches('pypy3', { tag: 'cpython-313', abi3: false })).toBe(false);
   });
 });
 
-describe("satisfiesPythonRange", () => {
+describe('satisfiesPythonRange', () => {
   it("treats an unparseable range as 'no constraint' (don't crash the host)", () => {
-    expect(satisfiesPythonRange("3.13.1", "")).toBe(true);
-    expect(satisfiesPythonRange("3.13.1", "garbage")).toBe(true);
+    expect(satisfiesPythonRange('3.13.1', '')).toBe(true);
+    expect(satisfiesPythonRange('3.13.1', 'garbage')).toBe(true);
   });
 
-  it("evaluates `>=` floors", () => {
-    expect(satisfiesPythonRange("3.13.0", ">=3.10")).toBe(true);
-    expect(satisfiesPythonRange("3.9.0", ">=3.10")).toBe(false);
+  it('evaluates `>=` floors', () => {
+    expect(satisfiesPythonRange('3.13.0', '>=3.10')).toBe(true);
+    expect(satisfiesPythonRange('3.9.0', '>=3.10')).toBe(false);
   });
 
-  it("evaluates compound ranges (AND)", () => {
-    expect(satisfiesPythonRange("3.13.1", ">=3.10,<4.0")).toBe(true);
-    expect(satisfiesPythonRange("4.0.0", ">=3.10,<4.0")).toBe(false);
+  it('evaluates compound ranges (AND)', () => {
+    expect(satisfiesPythonRange('3.13.1', '>=3.10,<4.0')).toBe(true);
+    expect(satisfiesPythonRange('4.0.0', '>=3.10,<4.0')).toBe(false);
   });
 
   it("treats `==3.13` as 'any 3.13.x' (major.minor exact)", () => {
-    expect(satisfiesPythonRange("3.13.5", "==3.13")).toBe(true);
-    expect(satisfiesPythonRange("3.12.0", "==3.13")).toBe(false);
+    expect(satisfiesPythonRange('3.13.5', '==3.13')).toBe(true);
+    expect(satisfiesPythonRange('3.12.0', '==3.13')).toBe(false);
   });
 });
 
-describe("resolvePython", () => {
+describe('resolvePython', () => {
   let testDir: string;
 
   beforeEach(() => {
-    testDir = mkdtempSync(join(tmpdir(), "mpak-python-resolver-"));
+    testDir = mkdtempSync(join(tmpdir(), 'mpak-python-resolver-'));
   });
 
   afterEach(() => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  function probeOk(tag = "cpython-313", version = "3.13.0") {
+  function probeOk(tag = 'cpython-313', version = '3.13.0') {
     return () => ({ cacheTag: tag, version });
   }
 
-  it("honors `mcp_config.command` verbatim — no silent rewrite (issue #90)", () => {
+  it('honors `mcp_config.command` verbatim — no silent rewrite (issue #90)', () => {
     const seen: string[] = [];
     const resolved = resolvePython({
       cacheDir: testDir,
-      manifestCommand: "python",
+      manifestCommand: 'python',
       declaredRange: undefined,
       env: {},
       probe: (cmd) => {
         seen.push(cmd);
-        return { cacheTag: "cpython-313", version: "3.13.0" };
+        return { cacheTag: 'cpython-313', version: '3.13.0' };
       },
     });
-    expect(seen).toEqual(["python"]); // no rewrite to 'python3'
-    expect(resolved.command).toBe("python");
-    expect(resolved.source).toBe("manifest");
+    expect(seen).toEqual(['python']); // no rewrite to 'python3'
+    expect(resolved.command).toBe('python');
+    expect(resolved.source).toBe('manifest');
   });
 
-  it("prefers MPAK_PYTHON over the manifest command", () => {
+  it('prefers MPAK_PYTHON over the manifest command', () => {
     const resolved = resolvePython({
       cacheDir: testDir,
-      manifestCommand: "python",
+      manifestCommand: 'python',
       declaredRange: undefined,
-      env: { MPAK_PYTHON: "/opt/homebrew/bin/python3.13" },
+      env: { MPAK_PYTHON: '/opt/homebrew/bin/python3.13' },
       probe: probeOk(),
     });
-    expect(resolved.command).toBe("/opt/homebrew/bin/python3.13");
-    expect(resolved.source).toBe("MPAK_PYTHON");
+    expect(resolved.command).toBe('/opt/homebrew/bin/python3.13');
+    expect(resolved.source).toBe('MPAK_PYTHON');
   });
 
-  it("falls back to `python3` when the manifest declares no command", () => {
+  it('falls back to `python3` when the manifest declares no command', () => {
     const resolved = resolvePython({
       cacheDir: testDir,
       manifestCommand: undefined,
@@ -199,15 +197,15 @@ describe("resolvePython", () => {
       env: {},
       probe: probeOk(),
     });
-    expect(resolved.command).toBe("python3");
-    expect(resolved.source).toBe("default");
+    expect(resolved.command).toBe('python3');
+    expect(resolved.source).toBe('default');
   });
 
-  it("throws PythonResolutionError when the chosen interpreter cannot be probed", () => {
+  it('throws PythonResolutionError when the chosen interpreter cannot be probed', () => {
     expect(() =>
       resolvePython({
         cacheDir: testDir,
-        manifestCommand: "python",
+        manifestCommand: 'python',
         declaredRange: undefined,
         env: {},
         probe: () => null,
@@ -217,67 +215,67 @@ describe("resolvePython", () => {
 
   it("throws an actionable ABI error when the bundle's compiled deps don't match", () => {
     // Bundle pins cpython-313 via a vendored .so file...
-    mkdirSync(join(testDir, "deps", "rpds"), { recursive: true });
-    writeFileSync(join(testDir, "deps", "rpds", "rpds.cpython-313-darwin.so"), "");
+    mkdirSync(join(testDir, 'deps', 'rpds'), { recursive: true });
+    writeFileSync(join(testDir, 'deps', 'rpds', 'rpds.cpython-313-darwin.so'), '');
 
     // ...but the chosen interpreter is 3.11.
     let err: unknown;
     try {
       resolvePython({
         cacheDir: testDir,
-        manifestCommand: "python3",
+        manifestCommand: 'python3',
         declaredRange: undefined,
         env: {},
-        probe: () => ({ cacheTag: "cpython-311", version: "3.11.9" }),
+        probe: () => ({ cacheTag: 'cpython-311', version: '3.11.9' }),
       });
     } catch (e) {
       err = e;
     }
     expect(err).toBeInstanceOf(PythonResolutionError);
     const msg = (err as Error).message;
-    expect(msg).toContain("Bundle requires");
-    expect(msg).toContain("cpython-313");
-    expect(msg).toContain("3.11.9");
-    expect(msg).toContain("MPAK_PYTHON"); // explicit override is the fix
+    expect(msg).toContain('Bundle requires');
+    expect(msg).toContain('cpython-313');
+    expect(msg).toContain('3.11.9');
+    expect(msg).toContain('MPAK_PYTHON'); // explicit override is the fix
   });
 
   it("throws when probed interpreter doesn't satisfy compatibility.runtimes.python", () => {
     expect(() =>
       resolvePython({
         cacheDir: testDir,
-        manifestCommand: "python3",
-        declaredRange: ">=3.13,<4.0",
+        manifestCommand: 'python3',
+        declaredRange: '>=3.13,<4.0',
         env: {},
-        probe: () => ({ cacheTag: "cpython-311", version: "3.11.9" }),
+        probe: () => ({ cacheTag: 'cpython-311', version: '3.11.9' }),
       }),
     ).toThrow(/compatibility\.runtimes\.python/);
   });
 
-  it("succeeds when ABI tag matches and range is satisfied", () => {
-    mkdirSync(join(testDir, "deps", "rpds"), { recursive: true });
-    writeFileSync(join(testDir, "deps", "rpds", "rpds.cpython-313-darwin.so"), "");
+  it('succeeds when ABI tag matches and range is satisfied', () => {
+    mkdirSync(join(testDir, 'deps', 'rpds'), { recursive: true });
+    writeFileSync(join(testDir, 'deps', 'rpds', 'rpds.cpython-313-darwin.so'), '');
 
     const resolved = resolvePython({
       cacheDir: testDir,
-      manifestCommand: "python3",
-      declaredRange: ">=3.13",
+      manifestCommand: 'python3',
+      declaredRange: '>=3.13',
       env: {},
-      probe: () => ({ cacheTag: "cpython-313", version: "3.13.1" }),
+      probe: () => ({ cacheTag: 'cpython-313', version: '3.13.1' }),
     });
-    expect(resolved.command).toBe("python3");
-    expect(resolved.cacheTag).toBe("cpython-313");
-    expect(resolved.version).toBe("3.13.1");
+    expect(resolved.command).toBe('python3');
+    expect(resolved.cacheTag).toBe('cpython-313');
+    expect(resolved.version).toBe('3.13.1');
   });
 
-  it("succeeds for pure-Python bundles regardless of interpreter ABI tag", () => {
+  it('succeeds for pure-Python bundles regardless of interpreter ABI tag', () => {
     // No deps/ in cacheDir → no ABI requirement to check.
     const resolved = resolvePython({
       cacheDir: testDir,
-      manifestCommand: "python3",
-      declaredRange: ">=3.10",
+      manifestCommand: 'python3',
+      declaredRange: '>=3.10',
       env: {},
-      probe: () => ({ cacheTag: "cpython-311", version: "3.11.9" }),
+      probe: () => ({ cacheTag: 'cpython-311', version: '3.11.9' }),
     });
-    expect(resolved.command).toBe("python3");
+    expect(resolved.command).toBe('python3');
   });
 });

--- a/packages/sdk-typescript/tests/python-resolver.test.ts
+++ b/packages/sdk-typescript/tests/python-resolver.test.ts
@@ -1,0 +1,283 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  abiMatches,
+  findRequiredAbi,
+  parseCpythonTag,
+  PythonResolutionError,
+  resolvePython,
+  satisfiesPythonRange,
+} from "../src/python-resolver.js";
+
+describe("parseCpythonTag", () => {
+  it("recognizes the canonical specific cpython tag", () => {
+    expect(parseCpythonTag("rpds.cpython-313-darwin.so")).toEqual({
+      tag: "cpython-313",
+      abi3: false,
+    });
+  });
+
+  it("recognizes a Linux extension with arch + libc in the platform tag", () => {
+    expect(parseCpythonTag("_pydantic_core.cpython-311-x86_64-linux-gnu.so")).toEqual({
+      tag: "cpython-311",
+      abi3: false,
+    });
+  });
+
+  it("recognizes Windows .pyd extensions", () => {
+    expect(parseCpythonTag("rpds.cpython-313-win_amd64.pyd")).toEqual({
+      tag: "cpython-313",
+      abi3: false,
+    });
+  });
+
+  it("recognizes abi3 with explicit floor", () => {
+    expect(
+      parseCpythonTag("_brotli.cpython-3.7-abi3-x86_64-linux-gnu.so"),
+    ).toEqual({
+      tag: "abi3",
+      abi3: true,
+      floor: { major: 3, minor: 7 },
+    });
+  });
+
+  it("recognizes bare abi3 with implicit 3.7 floor", () => {
+    expect(parseCpythonTag("_lib.abi3.so")).toEqual({
+      tag: "abi3",
+      abi3: true,
+      floor: { major: 3, minor: 7 },
+    });
+  });
+
+  it("returns null for non-extension files", () => {
+    expect(parseCpythonTag("module.py")).toBeNull();
+    expect(parseCpythonTag("README.md")).toBeNull();
+  });
+});
+
+describe("findRequiredAbi", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "mpak-python-resolver-"));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("returns null when there is no deps/ directory (pure-Python bundle)", () => {
+    expect(findRequiredAbi(testDir)).toBeNull();
+  });
+
+  it("returns null when deps/ has no compiled extensions", () => {
+    mkdirSync(join(testDir, "deps", "pure_pkg"), { recursive: true });
+    writeFileSync(join(testDir, "deps", "pure_pkg", "__init__.py"), "");
+    expect(findRequiredAbi(testDir)).toBeNull();
+  });
+
+  it("finds the cpython tag of a vendored compiled extension", () => {
+    mkdirSync(join(testDir, "deps", "rpds"), { recursive: true });
+    writeFileSync(join(testDir, "deps", "rpds", "rpds.cpython-313-darwin.so"), "");
+    expect(findRequiredAbi(testDir)).toEqual({ tag: "cpython-313", abi3: false });
+  });
+
+  it("prefers a specific cpython tag over an abi3 tag in the same bundle", () => {
+    // A bundle that mixes a version-pinned extension (e.g. pydantic_core) with
+    // an abi3-only extension is pinned by the version-specific one, since the
+    // host interpreter has to satisfy both.
+    mkdirSync(join(testDir, "deps", "a"), { recursive: true });
+    mkdirSync(join(testDir, "deps", "b"), { recursive: true });
+    writeFileSync(join(testDir, "deps", "a", "specific.cpython-313-darwin.so"), "");
+    writeFileSync(join(testDir, "deps", "b", "stable.abi3.so"), "");
+    expect(findRequiredAbi(testDir)).toEqual({ tag: "cpython-313", abi3: false });
+  });
+
+  it("returns abi3 when the bundle ships only stable-ABI extensions", () => {
+    mkdirSync(join(testDir, "deps", "c"), { recursive: true });
+    writeFileSync(join(testDir, "deps", "c", "stable.abi3.so"), "");
+    expect(findRequiredAbi(testDir)).toEqual({
+      tag: "abi3",
+      abi3: true,
+      floor: { major: 3, minor: 7 },
+    });
+  });
+});
+
+describe("abiMatches", () => {
+  it("requires exact match for version-specific cpython tags", () => {
+    expect(abiMatches("cpython-313", { tag: "cpython-313", abi3: false })).toBe(true);
+    expect(abiMatches("cpython-311", { tag: "cpython-313", abi3: false })).toBe(false);
+  });
+
+  it("accepts any cpython >= floor for abi3", () => {
+    const required = { tag: "abi3", abi3: true, floor: { major: 3, minor: 7 } };
+    expect(abiMatches("cpython-313", required)).toBe(true);
+    expect(abiMatches("cpython-37", required)).toBe(true);
+    expect(abiMatches("cpython-36", required)).toBe(false);
+  });
+
+  it("rejects non-cpython probed tags", () => {
+    expect(abiMatches("pypy3", { tag: "cpython-313", abi3: false })).toBe(false);
+  });
+});
+
+describe("satisfiesPythonRange", () => {
+  it("treats an unparseable range as 'no constraint' (don't crash the host)", () => {
+    expect(satisfiesPythonRange("3.13.1", "")).toBe(true);
+    expect(satisfiesPythonRange("3.13.1", "garbage")).toBe(true);
+  });
+
+  it("evaluates `>=` floors", () => {
+    expect(satisfiesPythonRange("3.13.0", ">=3.10")).toBe(true);
+    expect(satisfiesPythonRange("3.9.0", ">=3.10")).toBe(false);
+  });
+
+  it("evaluates compound ranges (AND)", () => {
+    expect(satisfiesPythonRange("3.13.1", ">=3.10,<4.0")).toBe(true);
+    expect(satisfiesPythonRange("4.0.0", ">=3.10,<4.0")).toBe(false);
+  });
+
+  it("treats `==3.13` as 'any 3.13.x' (major.minor exact)", () => {
+    expect(satisfiesPythonRange("3.13.5", "==3.13")).toBe(true);
+    expect(satisfiesPythonRange("3.12.0", "==3.13")).toBe(false);
+  });
+});
+
+describe("resolvePython", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "mpak-python-resolver-"));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function probeOk(tag = "cpython-313", version = "3.13.0") {
+    return () => ({ cacheTag: tag, version });
+  }
+
+  it("honors `mcp_config.command` verbatim — no silent rewrite (issue #90)", () => {
+    const seen: string[] = [];
+    const resolved = resolvePython({
+      cacheDir: testDir,
+      manifestCommand: "python",
+      declaredRange: undefined,
+      env: {},
+      probe: (cmd) => {
+        seen.push(cmd);
+        return { cacheTag: "cpython-313", version: "3.13.0" };
+      },
+    });
+    expect(seen).toEqual(["python"]); // no rewrite to 'python3'
+    expect(resolved.command).toBe("python");
+    expect(resolved.source).toBe("manifest");
+  });
+
+  it("prefers MPAK_PYTHON over the manifest command", () => {
+    const resolved = resolvePython({
+      cacheDir: testDir,
+      manifestCommand: "python",
+      declaredRange: undefined,
+      env: { MPAK_PYTHON: "/opt/homebrew/bin/python3.13" },
+      probe: probeOk(),
+    });
+    expect(resolved.command).toBe("/opt/homebrew/bin/python3.13");
+    expect(resolved.source).toBe("MPAK_PYTHON");
+  });
+
+  it("falls back to `python3` when the manifest declares no command", () => {
+    const resolved = resolvePython({
+      cacheDir: testDir,
+      manifestCommand: undefined,
+      declaredRange: undefined,
+      env: {},
+      probe: probeOk(),
+    });
+    expect(resolved.command).toBe("python3");
+    expect(resolved.source).toBe("default");
+  });
+
+  it("throws PythonResolutionError when the chosen interpreter cannot be probed", () => {
+    expect(() =>
+      resolvePython({
+        cacheDir: testDir,
+        manifestCommand: "python",
+        declaredRange: undefined,
+        env: {},
+        probe: () => null,
+      }),
+    ).toThrow(PythonResolutionError);
+  });
+
+  it("throws an actionable ABI error when the bundle's compiled deps don't match", () => {
+    // Bundle pins cpython-313 via a vendored .so file...
+    mkdirSync(join(testDir, "deps", "rpds"), { recursive: true });
+    writeFileSync(join(testDir, "deps", "rpds", "rpds.cpython-313-darwin.so"), "");
+
+    // ...but the chosen interpreter is 3.11.
+    let err: unknown;
+    try {
+      resolvePython({
+        cacheDir: testDir,
+        manifestCommand: "python3",
+        declaredRange: undefined,
+        env: {},
+        probe: () => ({ cacheTag: "cpython-311", version: "3.11.9" }),
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(PythonResolutionError);
+    const msg = (err as Error).message;
+    expect(msg).toContain("Bundle requires");
+    expect(msg).toContain("cpython-313");
+    expect(msg).toContain("3.11.9");
+    expect(msg).toContain("MPAK_PYTHON"); // explicit override is the fix
+  });
+
+  it("throws when probed interpreter doesn't satisfy compatibility.runtimes.python", () => {
+    expect(() =>
+      resolvePython({
+        cacheDir: testDir,
+        manifestCommand: "python3",
+        declaredRange: ">=3.13,<4.0",
+        env: {},
+        probe: () => ({ cacheTag: "cpython-311", version: "3.11.9" }),
+      }),
+    ).toThrow(/compatibility\.runtimes\.python/);
+  });
+
+  it("succeeds when ABI tag matches and range is satisfied", () => {
+    mkdirSync(join(testDir, "deps", "rpds"), { recursive: true });
+    writeFileSync(join(testDir, "deps", "rpds", "rpds.cpython-313-darwin.so"), "");
+
+    const resolved = resolvePython({
+      cacheDir: testDir,
+      manifestCommand: "python3",
+      declaredRange: ">=3.13",
+      env: {},
+      probe: () => ({ cacheTag: "cpython-313", version: "3.13.1" }),
+    });
+    expect(resolved.command).toBe("python3");
+    expect(resolved.cacheTag).toBe("cpython-313");
+    expect(resolved.version).toBe("3.13.1");
+  });
+
+  it("succeeds for pure-Python bundles regardless of interpreter ABI tag", () => {
+    // No deps/ in cacheDir → no ABI requirement to check.
+    const resolved = resolvePython({
+      cacheDir: testDir,
+      manifestCommand: "python3",
+      declaredRange: ">=3.10",
+      env: {},
+      probe: () => ({ cacheTag: "cpython-311", version: "3.11.9" }),
+    });
+    expect(resolved.command).toBe("python3");
+  });
+});

--- a/packages/sdk-typescript/tests/uv-resolver.test.ts
+++ b/packages/sdk-typescript/tests/uv-resolver.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveUv, UvResolutionError } from "../src/uv-resolver.js";
+
+describe("resolveUv", () => {
+  function probeOk(version = "0.4.22") {
+    return () => ({ version });
+  }
+
+  it("uses the spec-canonical default args when the manifest provides none", () => {
+    // From upstream `examples/hello-world-uv/manifest.json`:
+    //   "args": ["run", "--directory", "${__dirname}", "src/server.py"]
+    // Our default has to match shape-for-shape so embedders that don't honor
+    // `server.cwd` still find pyproject.toml.
+    const resolved = resolveUv({
+      cacheDir: "/tmp/cache/abc",
+      entryPoint: "src/server.py",
+      manifestCommand: undefined,
+      userArgs: [],
+      probe: probeOk(),
+    });
+    expect(resolved.command).toBe("uv");
+    expect(resolved.args).toEqual([
+      "run",
+      "--directory",
+      "/tmp/cache/abc",
+      "src/server.py",
+    ]);
+  });
+
+  it("defers to manifest-supplied args verbatim", () => {
+    // The manifest's args have already been ${__dirname}-substituted by the
+    // SDK before reaching the resolver — this test only pins the resolver's
+    // behavior of trusting them as-is.
+    const resolved = resolveUv({
+      cacheDir: "/tmp/cache/abc",
+      entryPoint: "src/server.py",
+      manifestCommand: "uv",
+      userArgs: ["run", "--directory", "/tmp/cache/abc", "src/server.py"],
+      probe: probeOk(),
+    });
+    expect(resolved.args).toEqual([
+      "run",
+      "--directory",
+      "/tmp/cache/abc",
+      "src/server.py",
+    ]);
+  });
+
+  it("honors manifest.command (e.g. an absolute uv path) verbatim", () => {
+    const resolved = resolveUv({
+      cacheDir: "/tmp/cache/abc",
+      entryPoint: "src/server.py",
+      manifestCommand: "/opt/local/bin/uv",
+      userArgs: [],
+      probe: probeOk(),
+    });
+    expect(resolved.command).toBe("/opt/local/bin/uv");
+  });
+
+  it("throws UvResolutionError with install instructions when uv is missing", () => {
+    let err: unknown;
+    try {
+      resolveUv({
+        cacheDir: "/tmp/cache/abc",
+        entryPoint: "src/server.py",
+        manifestCommand: undefined,
+        userArgs: [],
+        probe: () => null,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(UvResolutionError);
+    const msg = (err as Error).message;
+    expect(msg).toContain("not on PATH");
+    expect(msg).toContain("astral.sh/uv/install.sh");
+  });
+
+  it("returns the probed uv version for diagnostic logging", () => {
+    const resolved = resolveUv({
+      cacheDir: "/tmp/cache/abc",
+      entryPoint: "src/server.py",
+      manifestCommand: undefined,
+      userArgs: [],
+      probe: () => ({ version: "0.5.1" }),
+    });
+    expect(resolved.version).toBe("0.5.1");
+  });
+});

--- a/packages/sdk-typescript/tests/uv-resolver.test.ts
+++ b/packages/sdk-typescript/tests/uv-resolver.test.ts
@@ -1,69 +1,59 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
-import { resolveUv, UvResolutionError } from "../src/uv-resolver.js";
+import { resolveUv, UvResolutionError } from '../src/uv-resolver.js';
 
-describe("resolveUv", () => {
-  function probeOk(version = "0.4.22") {
+describe('resolveUv', () => {
+  function probeOk(version = '0.4.22') {
     return () => ({ version });
   }
 
-  it("uses the spec-canonical default args when the manifest provides none", () => {
+  it('uses the spec-canonical default args when the manifest provides none', () => {
     // From upstream `examples/hello-world-uv/manifest.json`:
     //   "args": ["run", "--directory", "${__dirname}", "src/server.py"]
     // Our default has to match shape-for-shape so embedders that don't honor
     // `server.cwd` still find pyproject.toml.
     const resolved = resolveUv({
-      cacheDir: "/tmp/cache/abc",
-      entryPoint: "src/server.py",
+      cacheDir: '/tmp/cache/abc',
+      entryPoint: 'src/server.py',
       manifestCommand: undefined,
       userArgs: [],
       probe: probeOk(),
     });
-    expect(resolved.command).toBe("uv");
-    expect(resolved.args).toEqual([
-      "run",
-      "--directory",
-      "/tmp/cache/abc",
-      "src/server.py",
-    ]);
+    expect(resolved.command).toBe('uv');
+    expect(resolved.args).toEqual(['run', '--directory', '/tmp/cache/abc', 'src/server.py']);
   });
 
-  it("defers to manifest-supplied args verbatim", () => {
+  it('defers to manifest-supplied args verbatim', () => {
     // The manifest's args have already been ${__dirname}-substituted by the
     // SDK before reaching the resolver — this test only pins the resolver's
     // behavior of trusting them as-is.
     const resolved = resolveUv({
-      cacheDir: "/tmp/cache/abc",
-      entryPoint: "src/server.py",
-      manifestCommand: "uv",
-      userArgs: ["run", "--directory", "/tmp/cache/abc", "src/server.py"],
+      cacheDir: '/tmp/cache/abc',
+      entryPoint: 'src/server.py',
+      manifestCommand: 'uv',
+      userArgs: ['run', '--directory', '/tmp/cache/abc', 'src/server.py'],
       probe: probeOk(),
     });
-    expect(resolved.args).toEqual([
-      "run",
-      "--directory",
-      "/tmp/cache/abc",
-      "src/server.py",
-    ]);
+    expect(resolved.args).toEqual(['run', '--directory', '/tmp/cache/abc', 'src/server.py']);
   });
 
-  it("honors manifest.command (e.g. an absolute uv path) verbatim", () => {
+  it('honors manifest.command (e.g. an absolute uv path) verbatim', () => {
     const resolved = resolveUv({
-      cacheDir: "/tmp/cache/abc",
-      entryPoint: "src/server.py",
-      manifestCommand: "/opt/local/bin/uv",
+      cacheDir: '/tmp/cache/abc',
+      entryPoint: 'src/server.py',
+      manifestCommand: '/opt/local/bin/uv',
       userArgs: [],
       probe: probeOk(),
     });
-    expect(resolved.command).toBe("/opt/local/bin/uv");
+    expect(resolved.command).toBe('/opt/local/bin/uv');
   });
 
-  it("throws UvResolutionError with install instructions when uv is missing", () => {
+  it('throws UvResolutionError with install instructions when uv is missing', () => {
     let err: unknown;
     try {
       resolveUv({
-        cacheDir: "/tmp/cache/abc",
-        entryPoint: "src/server.py",
+        cacheDir: '/tmp/cache/abc',
+        entryPoint: 'src/server.py',
         manifestCommand: undefined,
         userArgs: [],
         probe: () => null,
@@ -73,18 +63,18 @@ describe("resolveUv", () => {
     }
     expect(err).toBeInstanceOf(UvResolutionError);
     const msg = (err as Error).message;
-    expect(msg).toContain("not on PATH");
-    expect(msg).toContain("astral.sh/uv/install.sh");
+    expect(msg).toContain('not on PATH');
+    expect(msg).toContain('astral.sh/uv/install.sh');
   });
 
-  it("returns the probed uv version for diagnostic logging", () => {
+  it('returns the probed uv version for diagnostic logging', () => {
     const resolved = resolveUv({
-      cacheDir: "/tmp/cache/abc",
-      entryPoint: "src/server.py",
+      cacheDir: '/tmp/cache/abc',
+      entryPoint: 'src/server.py',
       manifestCommand: undefined,
       userArgs: [],
-      probe: () => ({ version: "0.5.1" }),
+      probe: () => ({ version: '0.5.1' }),
     });
-    expect(resolved.version).toBe("0.5.1");
+    expect(resolved.version).toBe('0.5.1');
   });
 });


### PR DESCRIPTION
Closes #90.

## Summary

- Replace the silent `python` → `python3` rewrite with a single ABI-validated probe. Resolution order: `MPAK_PYTHON` env override → `mcp_config.command` from the manifest → literal `python3`.
- Walk `deps/**/*.{so,pyd,dylib}` to extract the cpython ABI tag; probe the chosen interpreter once via `sys.implementation.cache_tag` and require it to match. abi3 wheels read the floor from the extension filename and accept any cpython ≥ floor.
- Cross-check `compatibility.runtimes.python` (semver) when declared.
- Failure path emits an actionable message — including how to set `MPAK_PYTHON` or install the right interpreter — instead of letting the bundle crash mid-import with `ModuleNotFoundError: No module named 'rpds.rpds'`.
- Log the resolved interpreter to stderr at startup: `[mpak] using python = /Users/.../python (3.13.5)` — removes "what's it actually running?" entirely.

Plus two adjacent fixes the same investigation surfaced:

## `type: uv` resolver gaps

- Probe `uv --version` first; throw with platform-specific install commands when missing instead of crashing mid-spawn with raw `ENOENT`.
- Default args for `type: uv` now match the upstream `examples/hello-world-uv` shape exactly: `["run", "--directory", cacheDir, entry_point]` — CWD-independent. The previous default only worked because the CLI happened to set `cwd: cacheDir`; embedders that don't honor `server.cwd` couldn't find `pyproject.toml`.
- Log resolved uv version to stderr, mirroring the python resolver.

## Schema alignment with MCPB v0.4

- Add `compatibility` block (`runtimes.python`, `runtimes.node`, `platforms`, plus catchall for client version constraints).
- Make `mcp_config` optional on `ManifestServerSchema` — MCPB v0.4 lets `type: "uv"` bundles omit it for host-managed execution.
- Make `mcp_config.command` and `mcp_config.args` optional within `McpConfigSchema`; resolver supplies sensible defaults per server type.
- Surfaces `compatibility.runtimes.python` to the resolver and unblocks parsing of spec-compliant uv bundles.
- 16 new schema tests including the verbatim hello-world-uv manifest from the MCPB spec, pinning conformance.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — green
  - `@nimblebrain/mpak-schemas`: 115 tests (was 99 — +16 manifest cases)
  - `@nimblebrain/mpak-sdk`: 277 tests (was 244 — +33: 18 python-resolver, 5 uv-resolver, 10 mpak end-to-end)
  - `@nimblebrain/mpak-registry`: 130 tests (unchanged)
  - `@nimblebrain/mpak-web`: 61 tests (unchanged)
  - `@nimblebrain/mpak`: 174 tests (unchanged)

## Repro from the issue

1. Have any Python ≠ 3.13 on PATH as `python3` (e.g. macOS system `/usr/bin/python3` is 3.9; Homebrew is 3.11).
2. `uv python install 3.13 --default --preview` — installs 3.13 and creates `~/.local/bin/python` but **not** `python3`.
3. `mpak bundle run @nimblebraininc/synapse-todo-board`

**Before this PR:** `ModuleNotFoundError: No module named 'rpds.rpds'` deep in an import chain. ~2 hours to debug to root cause.

**After this PR:**
```
Bundle requires cpython-313 (Python 3.13.x), but $(which python3) is cpython-311.
Install with: uv python install 3.13 --default
(or set MPAK_PYTHON to override.)
```

## Rebased

Rebased onto current main (which includes the just-merged #100). One conflict in `packages/schemas/src/manifest.ts` + `tests/manifest.test.ts` — kept main's `SafeRelativePathSchema` security check on `entry_point` and adopted this branch's optional-`mcp_config` change for v0.4 compliance. Both test suites union'd cleanly.