### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ apps/registry/data/
 # Implementation tasks
 .tasks/
 
+# Per-session Claude Code worktrees
+.claude/worktrees/
+
 # Misc
 *.bak
 *.tmp


### PR DESCRIPTION
Per-session Claude Code worktree directories shouldn't be tracked. They contain isolated working copies with their own state, created ad-hoc by the harness, and the same pattern is in nimblebrain/code's .gitignore.

Trivial; safe to fast-merge.