### PR TITLE
fix(registry): refresh package metadata on re-announce

### DIFF
--- a/apps/registry/src/db/repositories/package.repository.ts
+++ b/apps/registry/src/db/repositories/package.repository.ts
@@ -266,45 +266,42 @@ export class PackageRepository {
       where: { name: data.name },
     });
 
+    // Manifest-derived metadata refreshed on every announce so re-releases
+    // pick up changes (display name, description, icon, author, etc.).
+    // `undefined` values are skipped by Prisma, so a manifest that omits a
+    // field leaves the existing value intact rather than nulling it.
+    // Hoisted into one object and reused for both create and update so the
+    // two clauses cannot drift — the empty `update: {}` that this object
+    // replaces was itself a create/update drift bug.
+    const manifestMetadata = {
+      displayName: data.displayName,
+      description: data.description,
+      authorName: data.authorName,
+      authorEmail: data.authorEmail,
+      authorUrl: data.authorUrl,
+      homepage: data.homepage,
+      license: data.license,
+      iconUrl: data.iconUrl,
+      serverType: data.serverType,
+      githubRepo: data.githubRepo,
+    };
+
     const pkg = await client.package.upsert({
       where: { name: data.name },
       create: {
         name: data.name,
-        displayName: data.displayName,
-        description: data.description,
-        authorName: data.authorName,
-        authorEmail: data.authorEmail,
-        authorUrl: data.authorUrl,
-        homepage: data.homepage,
-        license: data.license,
-        iconUrl: data.iconUrl,
-        serverType: data.serverType,
+        ...manifestMetadata,
+        // Ownership/trust and version ordering are set only at creation.
+        // On update they are owned elsewhere: `latestVersion` by
+        // updateLatestVersion, `verified`/`claimedBy`/`claimedAt` by the
+        // claim flow — never overwritten by an announce.
         verified: data.verified ?? false,
         latestVersion: data.latestVersion,
         createdBy: data.createdBy,
-        githubRepo: data.githubRepo,
         claimedBy: data.claimedBy,
         claimedAt: data.claimedAt,
       },
-      // Refresh manifest-derived metadata on every announce so re-releases
-      // pick up changes (display name, description, icon, author, etc.).
-      // `undefined` values are skipped by Prisma, so a manifest that omits a
-      // field leaves the existing value intact rather than nulling it.
-      // Ownership/trust (verified, createdBy, claimedBy/At) and version
-      // ordering (latestVersion — handled by updateLatestVersion) are
-      // intentionally left untouched here.
-      update: {
-        displayName: data.displayName,
-        description: data.description,
-        authorName: data.authorName,
-        authorEmail: data.authorEmail,
-        authorUrl: data.authorUrl,
-        homepage: data.homepage,
-        license: data.license,
-        iconUrl: data.iconUrl,
-        serverType: data.serverType,
-        githubRepo: data.githubRepo,
-      },
+      update: manifestMetadata,
     });
 
     return { package: pkg, created: !existing };

--- a/apps/registry/src/db/repositories/package.repository.ts
+++ b/apps/registry/src/db/repositories/package.repository.ts
@@ -286,7 +286,25 @@ export class PackageRepository {
         claimedBy: data.claimedBy,
         claimedAt: data.claimedAt,
       },
-      update: {},
+      // Refresh manifest-derived metadata on every announce so re-releases
+      // pick up changes (display name, description, icon, author, etc.).
+      // `undefined` values are skipped by Prisma, so a manifest that omits a
+      // field leaves the existing value intact rather than nulling it.
+      // Ownership/trust (verified, createdBy, claimedBy/At) and version
+      // ordering (latestVersion — handled by updateLatestVersion) are
+      // intentionally left untouched here.
+      update: {
+        displayName: data.displayName,
+        description: data.description,
+        authorName: data.authorName,
+        authorEmail: data.authorEmail,
+        authorUrl: data.authorUrl,
+        homepage: data.homepage,
+        license: data.license,
+        iconUrl: data.iconUrl,
+        serverType: data.serverType,
+        githubRepo: data.githubRepo,
+      },
     });
 
     return { package: pkg, created: !existing };

--- a/apps/registry/tests/package.repository.test.ts
+++ b/apps/registry/tests/package.repository.test.ts
@@ -1,0 +1,112 @@
+/**
+ * PackageRepository.upsertPackage tests.
+ *
+ * Guards the announce metadata-refresh contract: an upsert must refresh
+ * manifest-derived metadata on the UPDATE path (the bug this fixes was an
+ * empty `update: {}`), while never letting an announce overwrite
+ * ownership/trust or version-ordering fields. Runs against a mocked
+ * transaction client — no database needed.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { TransactionClient } from '../src/db/client.js';
+import {
+  type CreatePackageData,
+  PackageRepository,
+} from '../src/db/repositories/package.repository.js';
+
+// Fields an announce must never touch on an existing package — owned by the
+// claim flow (verified/claimedBy/claimedAt), creation (createdBy), and
+// updateLatestVersion (latestVersion).
+const CREATE_ONLY_FIELDS = [
+  'verified',
+  'latestVersion',
+  'createdBy',
+  'claimedBy',
+  'claimedAt',
+] as const;
+
+function makeData(overrides: Partial<CreatePackageData> = {}): CreatePackageData {
+  return {
+    name: '@scope/example',
+    displayName: 'Example',
+    description: 'An example bundle',
+    authorName: 'Author',
+    authorEmail: 'author@example.com',
+    authorUrl: 'https://example.com',
+    homepage: 'https://example.com/home',
+    license: 'MIT',
+    iconUrl: 'https://example.com/icon.png',
+    serverType: 'python',
+    verified: true,
+    latestVersion: '1.2.3',
+    createdBy: 'user-1',
+    githubRepo: 'scope/example',
+    claimedBy: 'user-1',
+    claimedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeTx() {
+  const upsert = vi.fn().mockResolvedValue({ id: 'pkg-1', name: '@scope/example' });
+  const findUnique = vi.fn().mockResolvedValue(null);
+  const tx = { package: { upsert, findUnique } } as unknown as TransactionClient;
+  return { tx, upsert, findUnique };
+}
+
+describe('PackageRepository.upsertPackage', () => {
+  const repo = new PackageRepository();
+
+  it('refreshes manifest-derived metadata on the update path', async () => {
+    const { tx, upsert } = makeTx();
+    await repo.upsertPackage(makeData(), tx);
+
+    const { update } = upsert.mock.calls[0][0];
+    expect(update).toMatchObject({
+      displayName: 'Example',
+      description: 'An example bundle',
+      authorName: 'Author',
+      authorEmail: 'author@example.com',
+      authorUrl: 'https://example.com',
+      homepage: 'https://example.com/home',
+      license: 'MIT',
+      iconUrl: 'https://example.com/icon.png',
+      serverType: 'python',
+      githubRepo: 'scope/example',
+    });
+  });
+
+  it('never overwrites ownership/trust or version fields on update', async () => {
+    const { tx, upsert } = makeTx();
+    await repo.upsertPackage(makeData(), tx);
+
+    const { update } = upsert.mock.calls[0][0];
+    for (const field of CREATE_ONLY_FIELDS) {
+      expect(update, `update must not carry "${field}"`).not.toHaveProperty(field);
+    }
+  });
+
+  it('still sets ownership/trust and version fields on create', async () => {
+    const { tx, upsert } = makeTx();
+    await repo.upsertPackage(makeData(), tx);
+
+    const { create } = upsert.mock.calls[0][0];
+    expect(create).toMatchObject({
+      name: '@scope/example',
+      displayName: 'Example',
+      verified: true,
+      latestVersion: '1.2.3',
+      createdBy: 'user-1',
+      claimedBy: 'user-1',
+    });
+  });
+
+  it('reports created=false when the package already exists', async () => {
+    const { tx, findUnique } = makeTx();
+    findUnique.mockResolvedValueOnce({ id: 'pkg-1', name: '@scope/example' });
+
+    const { created } = await repo.upsertPackage(makeData(), tx);
+    expect(created).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`upsertPackage` has an empty `update: {}` clause. When a bundle already exists, an announce updates **nothing** about the package row — not `display_name`, `description`, `icon`, or `author`. The version moves only because `updateLatestVersion` runs separately.

Result: **44 of 49 registry bundles show `display_name: null`** even when republished with the field set in the manifest. It also means `description`/`icon`/`author` edits never propagate on re-release.

Confirmed live: `@nimblebraininc/abstract` v0.2.3 was released with `display_name: "Abstract"` in the manifest; CI green, `latest_version` moved to 0.2.3, but the API still returns `display_name: null`.

## Fix

Populate the `update` clause with the manifest-derived fields. Prisma skips `undefined`, so a manifest that omits a field preserves the existing value rather than nulling it. Ownership/trust (`verified`, `createdBy`, `claimedBy/At`) and version ordering (`latestVersion`, handled by `updateLatestVersion`) are intentionally left untouched.

## Verification

- `pnpm --filter @nimblebrain/mpak-registry typecheck` ✓
- `pnpm --filter @nimblebrain/mpak-registry lint` ✓
- `pnpm --filter @nimblebrain/mpak-registry test` ✓ (130 passed)
- `pnpm --filter @nimblebrain/mpak-registry build` ✓
- Post-deploy: re-announce abstract and confirm `display_name` populates.