### PR TITLE
fix(registry): stop egressing scan reports on hot read paths

### DIFF
--- a/apps/registry/src/db/repositories/package.repository.ts
+++ b/apps/registry/src/db/repositories/package.repository.ts
@@ -12,10 +12,35 @@ export type PackageVersionWithArtifacts = PackageVersion & {
   artifacts: Artifact[];
 };
 
-// Version with artifacts and security scans included
+// Minimal version fields for public version listings (see getVersions)
+export type VersionListItem = Pick<PackageVersion, 'version' | 'publishedAt' | 'downloadCount'>;
+
+/**
+ * Scan columns the listing/lookup paths actually use — just the MTF
+ * certification summary. The full `SecurityScan.report` JSON averages
+ * ~120 KB uncompressed on the wire (TOAST-compressed to ~16 KB on
+ * disk), so eager-loading whole scan rows on hot, crawled endpoints was
+ * the dominant source of database egress. These four scalars are all
+ * `scanToCertification` / the `/v1/bundles` certification block read;
+ * the report itself is served only by the dedicated scan endpoints,
+ * which run their own queries. Keep this in sync with `SCAN_CERT_SELECT`.
+ */
+export type ScanCertFields = Pick<
+  SecurityScan,
+  'certificationLevel' | 'controlsPassed' | 'controlsFailed' | 'controlsTotal'
+>;
+
+const SCAN_CERT_SELECT = {
+  certificationLevel: true,
+  controlsPassed: true,
+  controlsFailed: true,
+  controlsTotal: true,
+} as const satisfies Prisma.SecurityScanSelect;
+
+// Version with artifacts and the latest completed scan's certification summary
 export type PackageVersionWithArtifactsAndScans = PackageVersion & {
   artifacts: Artifact[];
-  securityScans: SecurityScan[];
+  securityScans: ScanCertFields[];
 };
 
 /**
@@ -23,12 +48,13 @@ export type PackageVersionWithArtifactsAndScans = PackageVersion & {
  * (when present) the latest completed security scan per version. The
  * shape `findPackageForServerLookup` and `findPackagesForServerListing`
  * return — both pull the same data in one query so the route layer
- * can compose `ServerDetail` without further round-trips.
+ * can compose `ServerDetail` without further round-trips. Scans are
+ * projected to the certification summary only (see {@link ScanCertFields}).
  */
 export type PackageForServerLookup = Package & {
   versions: (PackageVersion & {
     artifacts: Artifact[];
-    securityScans: SecurityScan[];
+    securityScans: ScanCertFields[];
   })[];
 };
 
@@ -346,6 +372,7 @@ export class PackageRepository {
               where: { status: 'completed' },
               orderBy: { startedAt: 'desc' },
               take: 1,
+              select: SCAN_CERT_SELECT,
             },
           },
         },
@@ -405,6 +432,7 @@ export class PackageRepository {
                 where: { status: 'completed' },
                 orderBy: { startedAt: 'desc' },
                 take: 1,
+                select: SCAN_CERT_SELECT,
               },
             },
           },
@@ -440,6 +468,7 @@ export class PackageRepository {
           where: { status: 'completed' },
           orderBy: { startedAt: 'desc' },
           take: 1,
+          select: SCAN_CERT_SELECT,
         },
       },
     });
@@ -465,13 +494,19 @@ export class PackageRepository {
   }
 
   /**
-   * Get all versions for a package
+   * Get the version list for a package — just the fields the public
+   * version listing renders. Deliberately omits the heavy `manifest`,
+   * `readme`, `serverJson`, `sourceIndex`, and `provenance` columns: a
+   * package's full version history was being fetched in full to emit
+   * three small fields per version, multiplying egress on the bundle
+   * detail endpoint.
    */
-  async getVersions(packageId: string, tx?: TransactionClient): Promise<PackageVersion[]> {
+  async getVersions(packageId: string, tx?: TransactionClient): Promise<VersionListItem[]> {
     const client = tx ?? getPrismaClient();
     return client.packageVersion.findMany({
       where: { packageId },
       orderBy: { publishedAt: 'desc' },
+      select: { version: true, publishedAt: true, downloadCount: true },
     });
   }
 

--- a/apps/registry/src/routes/mcp/v0.1/servers.ts
+++ b/apps/registry/src/routes/mcp/v0.1/servers.ts
@@ -232,7 +232,7 @@ export const mcpRegistryRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (request) => {
+    async (request, reply) => {
       const limit = Math.min(parseIntParam(request.query.limit, 100), 500);
       const skip = parseIntParam(request.query.cursor, 0);
       const updatedSince = parseUpdatedSince(request.query.updated_since);
@@ -264,6 +264,8 @@ export const mcpRegistryRoutes: FastifyPluginAsync = async (fastify) => {
       if (nextIdx < total) {
         response.metadata.next_cursor = String(nextIdx);
       }
+      // Public, crawled listing — let a shared cache absorb repeat hits.
+      reply.header('Cache-Control', 'public, max-age=60, s-maxage=300');
       return response;
     },
   );
@@ -287,7 +289,7 @@ export const mcpRegistryRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (request) => {
+    async (request, reply) => {
       const limit = Math.min(parseIntParam(request.query.limit, 100), 500);
       const skip = parseIntParam(request.query.cursor, 0);
       const { packages, total } = await packageRepo.findPackagesForServerListing(
@@ -312,6 +314,8 @@ export const mcpRegistryRoutes: FastifyPluginAsync = async (fastify) => {
       if (nextIdx < total) {
         response.metadata.next_cursor = String(nextIdx);
       }
+      // Public, crawled search — let a shared cache absorb repeat hits.
+      reply.header('Cache-Control', 'public, max-age=60, s-maxage=300');
       return response;
     },
   );

--- a/apps/registry/src/routes/v1/bundles.ts
+++ b/apps/registry/src/routes/v1/bundles.ts
@@ -174,7 +174,7 @@ export const bundleRoutes: FastifyPluginAsync = async (fastify) => {
         200: toJsonSchema(BundleSearchResponseSchema),
       },
     },
-    handler: async (request) => {
+    handler: async (request, reply) => {
       const { q, type, sort, limit, offset } = request.query;
 
       // Build filters
@@ -247,6 +247,8 @@ export const bundleRoutes: FastifyPluginAsync = async (fastify) => {
           has_more: offset + bundles.length < total,
         },
       };
+      // Public, crawled listing — let a shared cache absorb repeat hits.
+      reply.header('Cache-Control', 'public, max-age=60, s-maxage=300');
       return response;
     },
   });
@@ -268,7 +270,7 @@ export const bundleRoutes: FastifyPluginAsync = async (fastify) => {
         200: toJsonSchema(BundleDetailSchema),
       },
     },
-    handler: async (request) => {
+    handler: async (request, reply) => {
       const { scope, package: packageName } = request.params as { scope: string; package: string };
       const name = `@${scope}/${packageName}`;
 
@@ -305,6 +307,7 @@ export const bundleRoutes: FastifyPluginAsync = async (fastify) => {
             }
           : null;
 
+      reply.header('Cache-Control', 'public, max-age=60, s-maxage=300');
       return {
         name: pkg.name,
         display_name: pkg.displayName,


### PR DESCRIPTION
## Problem

Supabase reported ~14 GB of database egress for a **26 MB** database. Empirically traced (read-only, against production) to a single column.

The MCP registry listing (`/servers`, `/servers/search`), `/v1/bundles` list + detail, and the package server-lookup endpoints eager-load **entire `security_scans` rows** — including the full `report` JSON — when the only fields consumed are the four MTF certification scalars (`certificationLevel`, `controlsPassed/Failed/Total`).

### Measurements (production)

| Metric | Value |
|---|---|
| Total DB size | 26 MB |
| `report` on disk (TOAST-compressed) | ~16 KB avg |
| `report` over the wire (decompressed JSON) | **~120 KB avg, ~700 KB max** |
| `security_scans` rows fetched since 2025-12-08 | ~190k (index) |
| Est. egress from `report` alone | **~22 GB** |

`pg_column_size` reports the compressed on-disk size; Postgres ships the column **decompressed** (7.5× expansion), which is why the egress number dwarfs the dataset. Everything else in the schema combined is ~1–2 GB.

## Changes

- Add `SCAN_CERT_SELECT` and project the `securityScans` relation to the four cert fields in `findPackageForServerLookup`, `findPackagesForServerListing`, and `findVersionWithLatestScan`. The full report is still served by the dedicated scan endpoints (separate queries, untouched).
- Narrow `getVersions` to `{ version, publishedAt, downloadCount }` — the bundle detail page was fetching every version's `manifest`/`readme`/`serverJson`/`provenance` to emit three small fields per version.
- Add `Cache-Control: public, max-age=60, s-maxage=300` to the crawled JSON listing/detail endpoints so a shared cache absorbs repeat hits.

Read paths only; no schema or write changes.

## Verification

`pnpm typecheck`, `pnpm lint`, and `pnpm --filter @nimblebrain/mpak-registry test` (134 tests) all pass.

## Follow-up (not in this PR)

The version-level `readme`/`serverJson`/`sourceIndex` columns are still eager-loaded on the server-lookup paths (the secondary ~1 GB contributor). Worth a projection pass if egress doesn't drop far enough, but it requires a wider type refactor of `PackageForServerLookup`.