### PR TITLE
docs: RELEASING.md + idempotent publish workflows

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -57,9 +57,17 @@ jobs:
 
       - name: Publish to npm
         run: |
-          # pnpm pack resolves workspace:* to real versions; npm publish keeps provenance
-          pnpm pack
-          npm publish nimblebrain-mpak-*.tgz --provenance --access public
+          # The tag is the source of truth; publishing is idempotent so a re-pushed
+          # or backfilled tag won't fail on an already-published version.
+          PKG=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+            echo "$PKG@$VER already on npm — skipping publish (Release still created)"
+          else
+            # pnpm pack resolves workspace:* to real versions; npm publish keeps provenance
+            pnpm pack
+            npm publish nimblebrain-mpak-*.tgz --provenance --access public
+          fi
         working-directory: packages/cli
 
   release:

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -13,9 +13,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -33,9 +33,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -63,6 +63,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: apps/scanner/dist/
+          # Idempotent: a re-pushed/backfilled tag skips an already-published
+          # version instead of failing; the Release job still runs.
+          skip-existing: true
 
   publish-docker:
     needs: [verify, publish-pypi]

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         working-directory: apps/scanner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: apps/scanner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -74,7 +74,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract version from tag
         id: version
@@ -105,7 +105,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release

--- a/.github/workflows/schemas-publish.yml
+++ b/.github/workflows/schemas-publish.yml
@@ -13,9 +13,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -33,9 +33,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release

--- a/.github/workflows/schemas-publish.yml
+++ b/.github/workflows/schemas-publish.yml
@@ -57,9 +57,17 @@ jobs:
 
       - name: Publish to npm
         run: |
-          # pnpm pack resolves workspace:* to real versions; npm publish keeps provenance
-          pnpm pack
-          npm publish nimblebrain-mpak-schemas-*.tgz --provenance --access public
+          # The tag is the source of truth; publishing is idempotent so a re-pushed
+          # or backfilled tag won't fail on an already-published version.
+          PKG=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+            echo "$PKG@$VER already on npm — skipping publish (Release still created)"
+          else
+            # pnpm pack resolves workspace:* to real versions; npm publish keeps provenance
+            pnpm pack
+            npm publish nimblebrain-mpak-schemas-*.tgz --provenance --access public
+          fi
         working-directory: packages/schemas
 
   release:

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -59,6 +59,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/sdk-python/dist/
+          # Idempotent: a re-pushed/backfilled tag skips an already-published
+          # version instead of failing; the Release job still runs.
+          skip-existing: true
 
   release:
     needs: publish

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: packages/sdk-python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -37,7 +37,7 @@ jobs:
       run:
         working-directory: packages/sdk-python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -69,7 +69,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -13,9 +13,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -33,9 +33,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history + tags so we can find the previous same-prefix tag
       - name: Create GitHub Release

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -57,9 +57,17 @@ jobs:
 
       - name: Publish to npm
         run: |
-          # pnpm pack resolves workspace:* to real versions; npm publish keeps provenance
-          pnpm pack
-          npm publish nimblebrain-mpak-sdk-*.tgz --provenance --access public
+          # The tag is the source of truth; publishing is idempotent so a re-pushed
+          # or backfilled tag won't fail on an already-published version.
+          PKG=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if npm view "$PKG@$VER" version >/dev/null 2>&1; then
+            echo "$PKG@$VER already on npm — skipping publish (Release still created)"
+          else
+            # pnpm pack resolves workspace:* to real versions; npm publish keeps provenance
+            pnpm pack
+            npm publish nimblebrain-mpak-sdk-*.tgz --provenance --access public
+          fi
         working-directory: packages/sdk-typescript
 
   release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,13 +58,21 @@ isn't pushed, the release didn't happen.
 | `sdk-typescript` | `packages/sdk-typescript/package.json` | npm `@nimblebrain/mpak-sdk` | `sdk-typescript-v*` |
 | `schemas` | `packages/schemas/package.json` | npm `@nimblebrain/mpak-schemas` | `schemas-v*` |
 | `sdk-python` | `packages/sdk-python/pyproject.toml` | PyPI `mpak` | `sdk-python-v*` |
-| `scanner` | `apps/scanner/pyproject.toml` | PyPI `mpak-scanner` | `scanner-v*` |
+| `scanner` | `apps/scanner/pyproject.toml` | PyPI `mpak-scanner` **+ GHCR Docker image** | `scanner-v*` |
+
+`scanner` is the one package that ships two artifacts from a single tag: the PyPI
+package and a Docker image published to GHCR.
 
 ### Idempotency — re-tagging is safe
 
-The publish step is idempotent: if the version is already on npm/PyPI it **skips
-the publish** and the workflow still (re)creates the GitHub Release. So a
+The npm/PyPI publish step is idempotent: if the version is already published it
+**skips the publish** and the workflow still (re)creates the GitHub Release. So a
 re-pushed or backfilled tag never errors on "version already exists."
+
+One exception: `scanner`'s Docker image is **rebuilt and re-pushed** on a re-tag
+(it overwrites the same image tag rather than skipping). That's a benign
+overwrite, not a failure — but it does redundant work, so avoid re-tagging
+`scanner` casually.
 
 ### Recovering from drift
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,91 @@
+# Releasing
+
+mpak is a monorepo with two kinds of "release", deliberately handled differently:
+
+- **Libraries** — `cli`, `sdk-typescript`, `sdk-python`, `schemas`, `scanner` — are
+  **published** to npm / PyPI. You release one by pushing a git tag.
+- **Apps** — `registry`, `web` — are **deployed** services, not published packages.
+  They ship by commit, not by version.
+
+## Libraries: the tag *is* the release
+
+Each library versions independently. There is exactly **one way** to release one,
+and it is a single action: **push a tag.**
+
+```
+<package>-v<version>     e.g.  sdk-typescript-v0.8.0,  schemas-v0.4.0,  cli-v0.4.2
+```
+
+Pushing that tag triggers the package's workflow (`.github/workflows/<package>-publish.yml`),
+which runs three jobs:
+
+1. **verify** — build, lint, typecheck, test.
+2. **publish** — checks the tag matches the manifest version, then publishes to npm / PyPI.
+3. **release** — creates the GitHub Release with auto-generated notes.
+
+That is the entire model: **tag → CI publishes → CI creates the GitHub Release.**
+The tag is both the trigger and the source of truth. The GitHub Release and the
+npm/PyPI artifact are *products* of the tag — you never create them by hand.
+
+### To cut a release
+
+1. Bump the version in the package's manifest, on `main`:
+   - npm packages: `packages/<pkg>/package.json` → `version`
+   - PyPI packages: `pyproject.toml` → `[project].version`
+2. Commit it (e.g. `release: <pkg>@<version>`) and get it onto `main`.
+3. Tag that commit and push the tag:
+   ```sh
+   git tag <pkg>-v<version> <commit-on-main>
+   git push origin <pkg>-v<version>
+   ```
+4. Watch the Actions run. When it's green, npm/PyPI has the version and the
+   GitHub Release exists.
+
+### The one hard rule: never publish by hand
+
+Do **not** run `npm publish` / `uv publish` / `twine upload` from a laptop —
+ever. The tag-triggered workflow is the only sanctioned path. A manual publish
+puts npm/PyPI *ahead* of the git tags, which silently breaks release tracking
+(this is exactly the drift that produced untagged-but-published `sdk@0.8.0` /
+`schemas@0.4.0` and a bumped-but-never-published `sdk-python` 0.2.0). If the tag
+isn't pushed, the release didn't happen.
+
+### Package → registry → tag map
+
+| Package | Manifest | Registry | Tag prefix |
+|---|---|---|---|
+| `cli` | `packages/cli/package.json` | npm `@nimblebrain/mpak` | `cli-v*` |
+| `sdk-typescript` | `packages/sdk-typescript/package.json` | npm `@nimblebrain/mpak-sdk` | `sdk-typescript-v*` |
+| `schemas` | `packages/schemas/package.json` | npm `@nimblebrain/mpak-schemas` | `schemas-v*` |
+| `sdk-python` | `packages/sdk-python/pyproject.toml` | PyPI `mpak` | `sdk-python-v*` |
+| `scanner` | `apps/scanner/pyproject.toml` | PyPI `mpak-scanner` | `scanner-v*` |
+
+### Idempotency — re-tagging is safe
+
+The publish step is idempotent: if the version is already on npm/PyPI it **skips
+the publish** and the workflow still (re)creates the GitHub Release. So a
+re-pushed or backfilled tag never errors on "version already exists."
+
+### Recovering from drift
+
+If a manifest version is **ahead of its latest tag**, a release was bumped but
+never tagged (or published out-of-band). To reconcile, just push the missing tag
+at the release commit:
+
+```sh
+git tag <pkg>-v<version> <release-commit>
+git push origin <pkg>-v<version>
+```
+
+Because publish is idempotent, this is safe whether or not the version is already
+on the registry — it publishes if missing, skips if present, and creates the
+GitHub Release either way. Then verify `git tag` and the registry agree.
+
+## Apps: deployed by commit, not version
+
+`registry` (registry.mpak.dev) and `web` (mpak.dev) are long-running services,
+**not** published packages. They have no version tags. An operator deploys them
+from a chosen commit on `main`; the build is tagged with the commit's short SHA
+and rolled out through the deployment pipeline. There is no version to bump — you
+deploy a commit. (Operator deployment runbooks live with the deployment config,
+outside this repository.)


### PR DESCRIPTION
Makes the monorepo release model explicit and robust, after `sdk@0.8.0` / `schemas@0.4.0` went to npm without tags and `sdk-python` 0.2.0 was bumped but never published.

## The model (first-principled): the tag *is* the release
Every publish workflow triggers on `push: tags: <pkg>-v*`. So the single source of truth and trigger is the **git tag** — pushing `<pkg>-v<version>` runs verify → publish (npm/PyPI) → create GitHub Release. The Release and the published artifact are *products* of the tag; you never make them by hand. `RELEASING.md` documents this, the package→registry→tag map, the **hard rule (never publish manually)**, and a drift-recovery procedure.

Apps (`registry`, `web`) are the other track: deployed by commit (short-SHA image), not published — also documented.

## Idempotency (the missing robustness)
Every publish step now skips an already-published version instead of failing:
- **npm** (cli, sdk-typescript, schemas): `npm view` guard before publish
- **PyPI** (sdk-python, scanner): `skip-existing: true`

This is what lets us **backfill the missing tags safely** (re-tag an already-published version → workflow skips publish, still creates the Release).

## Follow-up (after merge) — reconcile the drift
1. `sdk-python-v0.2.0` → publishes 0.2.0 to PyPI (genuinely behind at 0.1.1)
2. `sdk-typescript-v0.8.0`, `schemas-v0.4.0` → backfill (publish skipped, Releases created)