### PR TITLE
Refocus mpak positioning on MCPB bundles (skills purge, stage 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mpak
 
-mpak is an open-source MCP bundle registry: search, download, publish, and scan MCPB bundles and skills.
+mpak is an open-source MCP bundle registry: search, download, publish, and scan MCPB bundles. It does one thing: package MCP servers as portable, security-scanned MCPB bundles. (Agent Skills are out of scope; skill packaging and distribution live in the `skills.sh` / `npx skills` ecosystem.)
 
 ## Monorepo Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # mpak
 
-mpak is an open-source MCP bundle registry: search, download, publish, and scan MCPB bundles. It does one thing: package MCP servers as portable, security-scanned MCPB bundles. (Agent Skills are out of scope; skill packaging and distribution live in the `skills.sh` / `npx skills` ecosystem.)
+mpak is an open-source MCP bundle registry: search, download, publish, and scan MCPB bundles. It does one thing — package MCP servers as portable, security-scanned MCPB bundles.
 
 ## Monorepo Structure
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ The `mpak` command-line tool. Built with [Commander.js](https://github.com/tj/co
 
 | Command | Description |
 |---------|-------------|
-| `mpak search <query>` | Search bundles |
-| `mpak bundle search <query>` | Search bundles |
+| `mpak search <query>` | Search bundles and skills |
+| `mpak bundle search <query>` | Search bundles only |
 | `mpak bundle show <name>` | Show bundle details and trust score |
 | `mpak bundle pull <name>` | Download a bundle |
 | `mpak bundle run <name>` | Download and run an MCP server |
@@ -278,13 +278,13 @@ cd apps/registry && npx prisma migrate dev && cd ../..
 
 ### 5. Seed example data
 
-Populate the database with example bundles so the UI has something to show:
+Populate the database with example skills so the UI has something to show:
 
 ```bash
 cd apps/registry && npm run db:seed && cd ../..
 ```
 
-This inserts a handful of example bundles with multiple versions, download counts, and trust scores. Safe to run multiple times (uses upserts).
+This inserts a handful of real skills (`@nimblebraininc/docs-auditor`, `@nimblebraininc/seo-optimizer`, `@nimblebraininc/strategic-thought-partner`) with multiple versions, download counts, tags, and triggers. Safe to run multiple times (uses upserts).
 
 To add more seed data, edit `apps/registry/prisma/seed.ts`.
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ my-server.mcpb
 
 `manifest.json` is the required entry point. It declares the package name, version, server type (`node`, `python`, or `binary`), platform-specific run commands, and the tools/prompts/resources the server exposes. The schema is defined in `packages/schemas`.
 
-### Skills
-
-Skills are the knowledge counterpart to bundles. While bundles give an AI agent the ability to *do* things (call APIs, run commands), skills give it the ability to *think* about things (domain expertise, workflow instructions).
-
-A skill is a markdown file (`SKILL.md`) with YAML frontmatter that declares metadata (name, description, category, trigger phrases). Skills can be packaged as `.skill` files (also ZIP archives) and distributed through the registry.
-
 ### Trust levels
 
 Every bundle receives a trust score from the MTF scanner. The score has two parts: a level (L1 through L4) and a numeric score (0 to 100) representing how many controls passed within that level. See the full framework at [mpaktrust.org](https://mpaktrust.org).
@@ -161,13 +155,13 @@ scanner  (standalone Python project, not in pnpm workspaces)
 
 ### `packages/schemas`
 
-Zod schemas and inferred TypeScript types for the MCPB manifest format, API responses, trust scores, skills, and validation helpers. This is the source of truth for data shapes across the entire stack.
+Zod schemas and inferred TypeScript types for the MCPB manifest format, API responses, trust scores, and validation helpers. This is the source of truth for data shapes across the entire stack.
 
-**Key exports:** `BundleSchema`, `SkillSchema`, `MpakJsonSchema`, `SearchParamsSchema`, validation functions.
+**Key exports:** `BundleSchema`, `MpakJsonSchema`, `SearchParamsSchema`, validation functions.
 
 ### `packages/sdk-typescript`
 
-TypeScript SDK for interacting with a mpak registry. Wraps the HTTP API with typed methods for searching, downloading, and inspecting bundles and skills.
+TypeScript SDK for interacting with a mpak registry. Wraps the HTTP API with typed methods for searching, downloading, and inspecting bundles.
 
 ```typescript
 import { MpakClient } from "@nimblebrain/mpak-sdk";
@@ -183,16 +177,11 @@ The `mpak` command-line tool. Built with [Commander.js](https://github.com/tj/co
 
 | Command | Description |
 |---------|-------------|
-| `mpak search <query>` | Search bundles and skills |
-| `mpak bundle search <query>` | Search bundles only |
+| `mpak search <query>` | Search bundles |
+| `mpak bundle search <query>` | Search bundles |
 | `mpak bundle show <name>` | Show bundle details and trust score |
 | `mpak bundle pull <name>` | Download a bundle |
 | `mpak bundle run <name>` | Download and run an MCP server |
-| `mpak skill search <query>` | Search skills |
-| `mpak skill show <name>` | Show skill details |
-| `mpak skill install <name>` | Install a skill to `~/.claude/skills/` |
-| `mpak skill validate <path>` | Validate a skill directory |
-| `mpak skill pack <path>` | Create a `.skill` bundle |
 | `mpak config set <pkg> <key=value>` | Set config for a package |
 | `mpak config get <pkg>` | Show config for a package |
 
@@ -205,7 +194,6 @@ The registry API server. Fastify with Prisma ORM on PostgreSQL. Handles bundle s
 **API surface:**
 
 - `/v1/bundles/*` - Native mpak API for bundle operations
-- `/v1/skills/*` - Native mpak API for skill operations
 - `/v0.1/servers` - MCP Registry spec compatibility (so MCP clients can discover bundles through the standard protocol)
 - `/app/*` - Routes used by the web UI (auth, admin, package claiming, scan results)
 - `/health` - Health check
@@ -217,7 +205,7 @@ The registry API server. Fastify with Prisma ORM on PostgreSQL. Handles bundle s
 
 ### `apps/web`
 
-React SPA for browsing the registry. Built with Vite, Tailwind CSS 4, React Router, and TanStack Query. Includes trust score visualization, bundle details, skill browsing, and an admin panel.
+React SPA for browsing the registry. Built with Vite, Tailwind CSS 4, React Router, and TanStack Query. Includes trust score visualization, bundle details, and an admin panel.
 
 ### `apps/scanner`
 
@@ -237,7 +225,7 @@ Produces a trust score from L1 (Basic) to L4 (Attested) based on which controls 
 
 ### `apps/docs`
 
-Documentation site. Covers CLI usage, bundle format, skills, integrations (VS Code, Claude Desktop, Cursor, Claude Code), and security controls.
+Documentation site. Covers CLI usage, bundle format, integrations (VS Code, Claude Desktop, Cursor, Claude Code), and security controls.
 
 ## Development setup
 
@@ -290,13 +278,13 @@ cd apps/registry && npx prisma migrate dev && cd ../..
 
 ### 5. Seed example data
 
-Populate the database with example skills so the UI has something to show:
+Populate the database with example bundles so the UI has something to show:
 
 ```bash
 cd apps/registry && npm run db:seed && cd ../..
 ```
 
-This inserts a handful of real skills (`@nimblebraininc/docs-auditor`, `@nimblebraininc/seo-optimizer`, `@nimblebraininc/strategic-thought-partner`) with multiple versions, download counts, tags, and triggers. Safe to run multiple times (uses upserts).
+This inserts a handful of example bundles with multiple versions, download counts, and trust scores. Safe to run multiple times (uses upserts).
 
 To add more seed data, edit `apps/registry/prisma/seed.ts`.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "mcpb",
     "model-context-protocol",
     "package-manager",
-    "agent-skills",
     "registry"
   ],
   "license": "Apache-2.0",


### PR DESCRIPTION
## Refocusing mpak: bundles only

mpak is being refocused to do **one thing well**: package MCP servers as portable, security-scanned MCPB bundles. Agent Skills support is being removed because the broader ecosystem is moving to `skills.sh` / `npx skills` for skill packaging and distribution.

This is **stage 1 of 4** — positioning and messaging only. No code is removed yet.

### Staged rollout
1. **Positioning & messaging** (this PR) — top-level docs
2. Web + docs — delete skills pages/components, on-domain redirects (`/skills*` → `/bundles`) — #125
3. Backend — remove `/v1/skills` routes, `SkillRepository`, skill schemas, SDK methods, `mpak skill` CLI; drop `Skill`/`SkillVersion` tables — #126
4. External consumers — `contributor-toolkit`, `org-profile`, template repos

### Changes here
- **README**: removed the Skills concept section, the `mpak skill *` CLI rows, the `/v1/skills/*` API-surface line, the `SkillSchema` export, and skill mentions in the SDK / web / docs blurbs
- **CLAUDE.md**: scope statement is now bundles-only
- **package.json**: dropped the `agent-skills` keyword

### Intentional staging boundary
This PR only **de-advertises** skills (removes inventory entries and narrative). It does **not** restate any live behavior as bundles-only: the `mpak search` command-table row still reads "Search bundles and skills" and the `npm run db:seed` step still describes seeding skills, because both track code that does not change until **stage 3 (#126)**. Reference docs that a reader executes must not lead the implementation. Those two edits land in #126 alongside the `program.ts` / `commands/search.ts` / `prisma/seed.ts` changes that make them true.

`CHANGELOG.md` history is left intact (the 0.1.0 entry is accurate for that release); the "Removed" entry lands with the code removal in #126.