### PR TITLE
fix(registry): preserve uppercase skill normalization through validation

### DIFF
--- a/apps/registry/tests/bundles.test.ts
+++ b/apps/registry/tests/bundles.test.ts
@@ -692,6 +692,9 @@ describe('Bundle Routes', () => {
     });
 
     it('normalises mixed-case scope for OIDC owner matching', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, { status: 404, statusText: 'Not Found' }),
+      );
       (verifyGitHubOIDC as Mock).mockResolvedValue({
         ...validOIDCClaims,
         repository_owner: 'MyOrg',
@@ -709,7 +712,8 @@ describe('Bundle Routes', () => {
       });
 
       const body = JSON.parse(res.payload);
-      expect(body.error?.message ?? '').not.toContain('Scope mismatch');
+      expect(res.statusCode).toBe(400);
+      expect(body.error.message).toBe('Failed to fetch release v1.0.0: Not Found');
     });
 
     it('rejects manifest without server type', async () => {

--- a/apps/registry/tests/bundles.test.ts
+++ b/apps/registry/tests/bundles.test.ts
@@ -667,6 +667,9 @@ describe('Bundle Routes', () => {
     });
 
     it('normalises uppercase package name to lowercase before validation', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, { status: 404, statusText: 'Not Found' }),
+      );
       (verifyGitHubOIDC as Mock).mockResolvedValue({
         ...validOIDCClaims,
         repository_owner: 'TestOrg',
@@ -683,11 +686,9 @@ describe('Bundle Routes', () => {
         },
       });
 
-      // Should NOT fail with "Invalid package name" — the name is normalised
-      // to lowercase before the regex check. It will fail later (GitHub fetch),
-      // but the validation gate must pass.
       const body = JSON.parse(res.payload);
-      expect(body.error?.message ?? '').not.toContain('Invalid package name');
+      expect(res.statusCode).toBe(400);
+      expect(body.error.message).toBe('Failed to fetch release v1.0.0: Not Found');
     });
 
     it('normalises mixed-case scope for OIDC owner matching', async () => {

--- a/apps/registry/tests/skills.test.ts
+++ b/apps/registry/tests/skills.test.ts
@@ -193,6 +193,9 @@ describe('Skill Routes', () => {
     });
 
     it('normalises mixed-case scope for OIDC owner matching', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, { status: 404, statusText: 'Not Found' }),
+      );
       (verifyGitHubOIDC as Mock).mockResolvedValue({
         ...validOIDCClaims,
         repository_owner: 'MyOrg',
@@ -210,7 +213,8 @@ describe('Skill Routes', () => {
       });
 
       const body = JSON.parse(res.payload);
-      expect(body.error?.message ?? '').not.toContain('Scope mismatch');
+      expect(res.statusCode).toBe(400);
+      expect(body.error.message).toBe('Failed to fetch release v1.0.0: Not Found');
     });
 
     it('rejects scope mismatch between skill name and OIDC owner', async () => {

--- a/apps/registry/tests/skills.test.ts
+++ b/apps/registry/tests/skills.test.ts
@@ -168,6 +168,9 @@ describe('Skill Routes', () => {
     });
 
     it('normalises uppercase skill name to lowercase before validation', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(null, { status: 404, statusText: 'Not Found' }),
+      );
       (verifyGitHubOIDC as Mock).mockResolvedValue({
         ...validOIDCClaims,
         repository_owner: 'TestOrg',
@@ -184,11 +187,9 @@ describe('Skill Routes', () => {
         },
       });
 
-      // Should NOT fail with "Invalid skill name" — the name is normalised
-      // to lowercase before the regex check. It will fail later (GitHub fetch),
-      // but the validation gate must pass.
       const body = JSON.parse(res.payload);
-      expect(body.error?.message ?? '').not.toContain('Invalid skill name');
+      expect(res.statusCode).toBe(400);
+      expect(body.error.message).toBe('Failed to fetch release v1.0.0: Not Found');
     });
 
     it('normalises mixed-case scope for OIDC owner matching', async () => {

--- a/apps/web/src/schemas/generated/skill.ts
+++ b/apps/web/src/schemas/generated/skill.ts
@@ -120,6 +120,13 @@ export const ScopedSkillNameSchema = z
   .string()
   .regex(/^@[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/, 'Scoped name format: @scope/name');
 
+const ScopedSkillNameInputSchema = z
+  .string()
+  .regex(
+    /^@[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9-]*$/,
+    'Scoped name format: @scope/name',
+  );
+
 /**
  * Skill artifact info for announce endpoint
  */
@@ -133,7 +140,7 @@ export const SkillArtifactSchema = z.object({
  * Announce request schema for POST /v1/skills/announce
  */
 export const SkillAnnounceRequestSchema = z.object({
-  name: ScopedSkillNameSchema,
+  name: ScopedSkillNameInputSchema,
   version: z.string(),
   skill: SkillFrontmatterSchema,
   release_tag: z.string(),

--- a/packages/schemas/src/skill.ts
+++ b/packages/schemas/src/skill.ts
@@ -95,6 +95,13 @@ export const ScopedSkillNameSchema = z
   .string()
   .regex(/^@[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/, 'Scoped name format: @scope/name');
 
+const ScopedSkillNameInputSchema = z
+  .string()
+  .regex(
+    /^@[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9-]*$/,
+    'Scoped name format: @scope/name',
+  );
+
 /** Skill artifact info for announce endpoint */
 export const SkillArtifactSchema = z.object({
   filename: z.string().regex(/\.skill$/, 'Must have .skill extension'),
@@ -104,7 +111,7 @@ export const SkillArtifactSchema = z.object({
 
 /** Announce request for POST /v1/skills/announce */
 export const SkillAnnounceRequestSchema = z.object({
-  name: ScopedSkillNameSchema,
+  name: ScopedSkillNameInputSchema,
   version: z.string(),
   skill: SkillFrontmatterSchema,
   release_tag: z.string(),


### PR DESCRIPTION
## Summary

- make uppercase normalization tests deterministic by mocking the downstream GitHub release lookup
- assert the exact `400` release-fetch failure for both bundle and skill announcements
- allow uppercase ASCII letters in the skill announce input schema so Fastify validation reaches the existing lowercase normalization
- keep canonical stored/output skill names lowercase-only and synchronize the generated web schema

## Reproduced gap

Before the schema change, `@TestOrg/my-skill` was rejected by Fastify request validation with `body/name must match pattern ...` before the route handler could call `toLowerCase()`. The previous negative assertion looked under `body.error.message`, while Fastify placed that validation failure in top-level `body.message`, so the regression passed unnoticed.

Closes #50.

## Validation

- `pnpm lint:ci`
- `pnpm typecheck` (7/7 tasks)
- `pnpm test` (all 11 tasks; registry 139, schemas 99, SDK 244, CLI 174, web 61)
- `pnpm build` (6/6 tasks)
- `npm pack --dry-run` in `packages/schemas` (8 files, 71.2 kB tarball)
- focused registry suites: 44/44 tests

The upstream Actions run is waiting for external-contributor approval, so local clean-room gates are reported above.