### PR TITLE
feat(scanner): run scan Jobs as mpak-scanner ServiceAccount (IRSA)

### DIFF
--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -118,4 +118,5 @@ pnpm typecheck
 | `SCANNER_IMAGE` | No | Scanner container image |
 | `SCANNER_IMAGE_TAG` | No | Scanner image tag |
 | `SCANNER_NAMESPACE` | No | K8s namespace for scans |
+| `SCANNER_SERVICE_ACCOUNT` | No | ServiceAccount for scan Job pods (default: `default`). Point at one carrying cloud identity (e.g. IRSA) scoped to bundle reads + report writes; it must exist in `SCANNER_NAMESPACE` |
 | `SCANNER_CALLBACK_SECRET` | No | Scanner callback auth secret |

--- a/apps/registry/src/config.ts
+++ b/apps/registry/src/config.ts
@@ -51,6 +51,7 @@ export const config = {
     image: process.env.SCANNER_IMAGE || '',
     imageTag: process.env.SCANNER_IMAGE_TAG || 'latest',
     namespace: process.env.SCANNER_NAMESPACE || 'security-scanning',
+    serviceAccountName: process.env.SCANNER_SERVICE_ACCOUNT || 'default',
     callbackSecret: process.env.SCANNER_CALLBACK_SECRET || '',
     callbackUrl:
       process.env.SCANNER_CALLBACK_URL ||

--- a/apps/registry/src/services/scanner.ts
+++ b/apps/registry/src/services/scanner.ts
@@ -82,6 +82,11 @@ export async function triggerScan(params: TriggerScanParams): Promise<TriggerSca
         },
         spec: {
           restartPolicy: 'Never',
+          // ServiceAccount the scan pod runs as. Point SCANNER_SERVICE_ACCOUNT
+          // at one carrying cloud identity (e.g. IRSA / workload identity) scoped
+          // to reading the bundle under scan and writing its report; defaults to
+          // the namespace default SA.
+          serviceAccountName: config.scanner.serviceAccountName,
           securityContext: {
             runAsNonRoot: true,
             runAsUser: 1000,


### PR DESCRIPTION
## What

Set `serviceAccountName` on the scan Job pod, configurable via `SCANNER_SERVICE_ACCOUNT`.

## Why

The scan Job pod ran under the `default` ServiceAccount and got its AWS credentials from the scanner ExternalSecret — a static key **shared with the API that carries broad registry write access**. Binding the pod to a dedicated ServiceAccount lets operators give it a scoped cloud identity (e.g. IRSA / workload identity) for just reading the bundle under scan and writing its report, instead of that shared key.

## Non-breaking

Defaults to `default` (the namespace default SA), so existing self-hosted scanner deployments behave exactly as before. Operators opt into a scoped identity by pointing `SCANNER_SERVICE_ACCOUNT` at an SA that carries cloud identity — documented in the registry README. The SA must exist in the scan namespace.

The NimbleBrain deployment sets it to an IRSA-annotated SA (`NimbleBrainInc/deployments#198`); once the static key is removed from the scanner secret (`NimbleBrainInc/deployments#199`), boto3 falls through to IRSA — no change to the job code needed.

## Related

- Least-privilege follow-up to the RCE fix in `NimbleBrainInc/mpak#130` (issue `NimbleBrainInc/mpak#131`).
- Deployment wiring: `NimbleBrainInc/deployments#198`, `NimbleBrainInc/deployments#199`, `NimbleBrainInc/infra#164`.

CI runs the full `pnpm verify`; the change is a single optional `V1PodSpec` field plus a string config default.
