### PR TITLE
test(scanner): extract buildScanJob + assert pod security posture

### DIFF
--- a/apps/registry/src/services/scanner.ts
+++ b/apps/registry/src/services/scanner.ts
@@ -44,25 +44,22 @@ function shortId(uuid: string): string {
 }
 
 /**
- * Trigger a security scan for a bundle
+ * Build the K8s Job manifest for a bundle scan.
+ *
+ * Pure (no cluster calls) so the pod's security posture — the scoped
+ * ServiceAccount, non-root user, dropped capabilities, and read-only reach —
+ * can be asserted directly in tests and can't be silently dropped by a refactor.
  */
-export async function triggerScan(params: TriggerScanParams): Promise<TriggerScanResult> {
-  const { scanId, bundleS3Key, packageName, version } = params;
-
-  if (!config.scanner.enabled) {
-    console.log(`[scanner] Scanning disabled, skipping scan for ${packageName}@${version}`);
-    return { jobName: 'disabled' };
-  }
-
+export function buildScanJob(params: TriggerScanParams): k8s.V1Job {
+  const { scanId, bundleS3Key, packageName } = params;
   const jobName = `scan-${shortId(scanId)}`;
-  const namespace = config.scanner.namespace;
 
-  const job: k8s.V1Job = {
+  return {
     apiVersion: 'batch/v1',
     kind: 'Job',
     metadata: {
       name: jobName,
-      namespace,
+      namespace: config.scanner.namespace,
       labels: {
         app: 'mpak-scanner',
         'scan-id': scanId,
@@ -149,9 +146,24 @@ export async function triggerScan(params: TriggerScanParams): Promise<TriggerSca
       },
     },
   };
+}
+
+/**
+ * Trigger a security scan for a bundle
+ */
+export async function triggerScan(params: TriggerScanParams): Promise<TriggerScanResult> {
+  const { scanId, packageName, version } = params;
+
+  if (!config.scanner.enabled) {
+    console.log(`[scanner] Scanning disabled, skipping scan for ${packageName}@${version}`);
+    return { jobName: 'disabled' };
+  }
+
+  const jobName = `scan-${shortId(scanId)}`;
+  const job = buildScanJob(params);
 
   const client = getK8sClient();
-  await client.createNamespacedJob({ namespace, body: job });
+  await client.createNamespacedJob({ namespace: config.scanner.namespace, body: job });
 
   console.log(`[scanner] Created scan Job ${jobName} for ${packageName}@${version}`);
 

--- a/apps/registry/src/services/scanner.ts
+++ b/apps/registry/src/services/scanner.ts
@@ -44,6 +44,14 @@ function shortId(uuid: string): string {
 }
 
 /**
+ * Deterministic Job name for a scan. Single source so buildScanJob (which sets
+ * metadata.name) and triggerScan (which logs and returns it) cannot drift.
+ */
+function scanJobName(scanId: string): string {
+  return `scan-${shortId(scanId)}`;
+}
+
+/**
  * Build the K8s Job manifest for a bundle scan.
  *
  * Pure (no cluster calls) so the pod's security posture — the scoped
@@ -52,7 +60,7 @@ function shortId(uuid: string): string {
  */
 export function buildScanJob(params: TriggerScanParams): k8s.V1Job {
   const { scanId, bundleS3Key, packageName } = params;
-  const jobName = `scan-${shortId(scanId)}`;
+  const jobName = scanJobName(scanId);
 
   return {
     apiVersion: 'batch/v1',
@@ -159,7 +167,7 @@ export async function triggerScan(params: TriggerScanParams): Promise<TriggerSca
     return { jobName: 'disabled' };
   }
 
-  const jobName = `scan-${shortId(scanId)}`;
+  const jobName = scanJobName(scanId);
   const job = buildScanJob(params);
 
   const client = getK8sClient();

--- a/apps/registry/tests/scanner-job.test.ts
+++ b/apps/registry/tests/scanner-job.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Scan Job manifest tests.
+ *
+ * buildScanJob is the single place the scanner's pod security posture is
+ * defined. These assertions lock in the least-privilege intent (scoped
+ * ServiceAccount, non-root, dropped capabilities) so a future refactor can't
+ * silently weaken it.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/config.js', () => ({
+  config: {
+    scanner: {
+      enabled: true,
+      image: '533267450054.dkr.ecr.us-east-1.amazonaws.com/mpak-scanner',
+      imageTag: 'latest',
+      namespace: 'security-scanning',
+      serviceAccountName: 'mpak-scanner',
+      callbackUrl: 'http://mpak-api.apps.svc.cluster.local:3200/app/scan-results',
+      secretName: 'mpak-scanner-secrets',
+      s3ResultPrefix: 'scan-results/',
+      ttlSeconds: 3600,
+      activeDeadlineSeconds: 900,
+    },
+    storage: {
+      s3: { bucket: 'mpak-cdn', region: 'us-east-1' },
+    },
+  },
+}));
+
+const { buildScanJob } = await import('../src/services/scanner.js');
+
+const params = {
+  scanId: '00000000-0000-0000-0000-000000000001',
+  bundleS3Key: 'packages/@scope/name/1.0.0/bundle.mcpb',
+  packageName: '@scope/name',
+  version: '1.0.0',
+};
+
+describe('buildScanJob', () => {
+  it('runs the pod under the configured ServiceAccount', () => {
+    const podSpec = buildScanJob(params).spec?.template?.spec;
+    expect(podSpec?.serviceAccountName).toBe('mpak-scanner');
+  });
+
+  it('pins the least-privilege pod security context', () => {
+    const podSpec = buildScanJob(params).spec?.template?.spec;
+    expect(podSpec?.securityContext).toMatchObject({
+      runAsNonRoot: true,
+      runAsUser: 1000,
+      seccompProfile: { type: 'RuntimeDefault' },
+    });
+  });
+
+  it('drops all capabilities and blocks privilege escalation on the container', () => {
+    const container = buildScanJob(params).spec?.template?.spec?.containers?.[0];
+    expect(container?.securityContext?.allowPrivilegeEscalation).toBe(false);
+    expect(container?.securityContext?.capabilities?.drop).toEqual(['ALL']);
+  });
+
+  it('targets the bundle under scan with the scanner image', () => {
+    const job = buildScanJob(params);
+    expect(job.metadata?.name).toMatch(/^scan-/);
+    const container = job.spec?.template?.spec?.containers?.[0];
+    expect(container?.image).toBe(
+      '533267450054.dkr.ecr.us-east-1.amazonaws.com/mpak-scanner:latest',
+    );
+    expect(container?.env).toContainEqual({ name: 'BUNDLE_S3_KEY', value: params.bundleS3Key });
+  });
+});

--- a/apps/registry/tests/scanner-job.test.ts
+++ b/apps/registry/tests/scanner-job.test.ts
@@ -13,11 +13,11 @@ vi.mock('../src/config.js', () => ({
   config: {
     scanner: {
       enabled: true,
-      image: '533267450054.dkr.ecr.us-east-1.amazonaws.com/mpak-scanner',
+      image: 'registry.example.com/mpak-scanner',
       imageTag: 'latest',
       namespace: 'security-scanning',
       serviceAccountName: 'mpak-scanner',
-      callbackUrl: 'http://mpak-api.apps.svc.cluster.local:3200/app/scan-results',
+      callbackUrl: 'http://mpak-api.internal/app/scan-results',
       secretName: 'mpak-scanner-secrets',
       s3ResultPrefix: 'scan-results/',
       ttlSeconds: 3600,
@@ -63,9 +63,7 @@ describe('buildScanJob', () => {
     const job = buildScanJob(params);
     expect(job.metadata?.name).toMatch(/^scan-/);
     const container = job.spec?.template?.spec?.containers?.[0];
-    expect(container?.image).toBe(
-      '533267450054.dkr.ecr.us-east-1.amazonaws.com/mpak-scanner:latest',
-    );
+    expect(container?.image).toBe('registry.example.com/mpak-scanner:latest');
     expect(container?.env).toContainEqual({ name: 'BUNDLE_S3_KEY', value: params.bundleS3Key });
   });
 });


### PR DESCRIPTION
## What

Extract the scan Job manifest out of `triggerScan` into a pure `buildScanJob(params): k8s.V1Job`, and add `scanner-job.test.ts` asserting the pod's security posture: scoped `serviceAccountName`, `runAsNonRoot`, `runAsUser: 1000`, seccomp `RuntimeDefault`, `allowPrivilegeEscalation: false`, `capabilities.drop: ['ALL']`, plus the bundle key and scanner image.

## Why

Both QA reviews of `NimbleBrainInc/mpak#132` independently flagged the same gap: the security-bearing Job manifest had zero coverage (`scanner.test.ts` mocks the service out for route tests), so a future refactor could silently weaken the least-privilege intent with nothing failing. This creates the seam and locks the fields in.

No behavior change — `triggerScan` builds the same manifest via `buildScanJob`. `pnpm --filter @nimblebrain/mpak-registry typecheck && test` green (143 tests).

Follow-up to `NimbleBrainInc/mpak#132` (issue `NimbleBrainInc/mpak#131`).
