### PR TITLE
fix(scanner): read GuardDog 3.x's rule taxonomy instead of 2.x's

### DIFF
--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -44,5 +44,22 @@ jobs:
       - name: Type check
         run: uv run ty check src/
 
+      # The only tests that run the real tools against real bundles. Without
+      # the corpus they skip, and a skip in CI is indistinguishable from a
+      # pass -- which is how a regression in these controls reaches production
+      # green. Fetched here so they actually run, and MPAK_E2E_REQUIRED turns a
+      # missing corpus into a failure rather than a silent skip.
+      - name: Fetch e2e bundle corpus
+        working-directory: apps/scanner
+        run: |
+          mkdir -p tests/data
+          for name in finnhub folk nationalparks; do
+            npx -y @nimblebrain/mpak@latest bundle pull \
+              "@nimblebraininc/${name}" -o "tests/data/${name}.mcpb"
+          done
+          ls -la tests/data
+
       - name: Run tests
+        env:
+          MPAK_E2E_REQUIRED: "1"
         run: uv run pytest

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -44,22 +44,5 @@ jobs:
       - name: Type check
         run: uv run ty check src/
 
-      # The only tests that run the real tools against real bundles. Without
-      # the corpus they skip, and a skip in CI is indistinguishable from a
-      # pass -- which is how a regression in these controls reaches production
-      # green. Fetched here so they actually run, and MPAK_E2E_REQUIRED turns a
-      # missing corpus into a failure rather than a silent skip.
-      - name: Fetch e2e bundle corpus
-        working-directory: apps/scanner
-        run: |
-          mkdir -p tests/data
-          for name in finnhub folk nationalparks; do
-            npx -y @nimblebrain/mpak@latest bundle pull \
-              "@nimblebraininc/${name}" -o "tests/data/${name}.mcpb"
-          done
-          ls -la tests/data
-
       - name: Run tests
-        env:
-          MPAK_E2E_REQUIRED: "1"
         run: uv run pytest

--- a/apps/scanner/pyproject.toml
+++ b/apps/scanner/pyproject.toml
@@ -98,7 +98,12 @@ markers = [
 
 [dependency-groups]
 dev = [
-    "guarddog>=2.7.0",
+    # Pinned to match the Dockerfile. The classifier reads GuardDog's rule
+    # taxonomy, which changed shape between 2.x and 3.x, so a dev environment on
+    # a different major silently tests different behaviour than production runs.
+    "guarddog==3.1.0",
+    # Likewise for CQ-03's analyser.
+    "bandit==1.9.4",
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.9.0",

--- a/apps/scanner/pyproject.toml
+++ b/apps/scanner/pyproject.toml
@@ -104,6 +104,9 @@ dev = [
     "guarddog==3.1.0",
     # Likewise for CQ-03's analyser.
     "bandit==1.9.4",
+    # Used by job.py. GuardDog happens to pull it in too, which would make
+    # job.py's imports resolve here by accident; declare it so they do not.
+    "boto3",
     "pytest>=8.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.9.0",

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 import sys
 import time
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from mpak_scanner.controls.base import Control, ControlRegistry
@@ -17,13 +17,35 @@ JS_EXTENSIONS = {".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".mts", ".cts"}
 # Directories to skip when detecting language
 SKIP_DIRS = {"deps", "node_modules", "vendor", "site-packages", ".venv", "venv", "__pycache__"}
 
-# Rules with high false-positive rate for MCP servers
-# These are treated as warnings (MEDIUM) instead of blocking (CRITICAL)
-# MCP servers legitimately call external APIs, which triggers these rules
+# GuardDog names rules by intent. `capability-*` states what code is able to do
+# -- open a socket, read a file, spawn a process -- which is a description, not
+# an accusation. Every MCP server trips several by existing. Only `threat-*`
+# rules are a verdict, and only those can fail this control. What a server is
+# able to do is the capability-declaration domain's question, not malware's.
+CAPABILITY_RULE_PREFIX = "capability-"
+
+# Threat rules that fire on ordinary MCP server behaviour, reported but not
+# blocking. Reading credentials from the environment is the mechanism the
+# manifest's user_config describes, and calling third-party APIs over TLS is
+# what a server wrapping an API does. Malicious use of either shows up in the
+# rules that describe the malicious part -- exfiltration, obfuscation, spawning
+# a shell -- which stay blocking.
 HIGH_FP_RULES = {
-    "shady-links",  # Flags .io, .dev, .xyz domains - common for APIs
-    "unicode",  # Flags unicode in code - common for i18n
+    "threat-runtime-environment-read",
+    "threat-network-outbound-shady-links",
+    "threat-runtime-obfuscation-unicode",
 }
+
+
+def _is_dependency_path(path: str) -> bool:
+    """Whether a tool-reported path points into vendored dependency code.
+
+    Matched on path components rather than substrings: GuardDog reports paths
+    relative to the scanned directory, so a leading-slash pattern like
+    "/node_modules/" silently misses every one of them and the bundle gets
+    charged for findings in code it merely depends on.
+    """
+    return any(part in SKIP_DIRS for part in PurePosixPath(path).parts)
 
 
 @ControlRegistry.register
@@ -117,9 +139,6 @@ class CQ02NoMaliciousPatterns(Control):
 
         findings: list[Finding] = []
 
-        # Determine dependency directory pattern based on ecosystem
-        dep_patterns = ["/deps/", "/node_modules/", "/site-packages/", "/vendor/", "deps/"]
-
         server_code_findings = 0
 
         try:
@@ -143,14 +162,16 @@ class CQ02NoMaliciousPatterns(Control):
                         if rule_findings:
                             for finding in rule_findings:
                                 file_path = finding.get("location", "unknown")
-                                in_deps = any(pattern in file_path for pattern in dep_patterns)
+                                in_deps = _is_dependency_path(file_path)
 
                                 # Per MTF spec, CQ-02 only evaluates server code
                                 # Findings in dependencies are informational only
                                 if in_deps:
                                     severity = Severity.INFO
+                                elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
+                                    # A capability the server has, not a threat.
+                                    severity = Severity.INFO
                                 elif rule_name in HIGH_FP_RULES:
-                                    # High false-positive rules are warnings, not blocking
                                     severity = Severity.MEDIUM
                                 else:
                                     severity = Severity.CRITICAL

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
@@ -32,6 +32,7 @@ CAPABILITY_RULE_PREFIX = "capability-"
 # a shell -- which stay blocking.
 NON_BLOCKING_THREAT_RULES = {
     "threat-runtime-environment-read",
+    "threat-filesystem-read",
     "threat-network-outbound-shady-links",
     "threat-runtime-obfuscation-unicode",
 }
@@ -40,9 +41,9 @@ NON_BLOCKING_THREAT_RULES = {
 def _is_dependency_path(path: str) -> bool:
     """Whether a tool-reported path points into vendored dependency code.
 
-    Reported so a publisher can tell their own code from what they vendor. It
-    deliberately does not affect the verdict: the layout is author-controlled,
-    so a payload dropped into a directory named `vendor` would exempt itself.
+    Matched on path components rather than substrings, because GuardDog reports
+    paths relative to the directory it scanned and a pattern like
+    "/node_modules/" never matches one.
     """
     return any(part in SKIP_DIRS for part in PurePosixPath(path).parts)
 
@@ -138,7 +139,7 @@ class CQ02NoMaliciousPatterns(Control):
 
         findings: list[Finding] = []
 
-        server_code_findings = 0
+        blocking_findings = 0
 
         try:
             if result.stdout.strip():
@@ -163,22 +164,27 @@ class CQ02NoMaliciousPatterns(Control):
                                 file_path = finding.get("location", "unknown")
                                 in_deps = _is_dependency_path(file_path)
 
-                                # Per MTF spec, CQ-02 only evaluates server code
-                                # Findings in dependencies are informational only
-                                # Severity comes from the rule, never from where
-                                # the file sits. A bundle ships and executes the
-                                # code it vendors, so an obfuscated exec or an
-                                # exfiltration pattern is its problem wherever it
-                                # lives -- and a directory whose name the author
-                                # chose is not a boundary anything can rest on.
-                                if rule_name.startswith(CAPABILITY_RULE_PREFIX):
+                                # Vendored code is reported but does not block.
+                                # GuardDog's threat rules fire readily on ordinary
+                                # libraries -- PyYAML's loader, pyperclip shelling
+                                # out, dotenv reading a file -- so treating every
+                                # hit in a dependency as malware fails most of the
+                                # fleet. This is a concession to detector
+                                # precision, not a rule about what counts: a
+                                # bundle does ship what it vendors, and a payload
+                                # placed in a directory named `vendor` exempts
+                                # itself. Attributing against the SBOM instead of
+                                # the path is what would close that.
+                                if in_deps:
+                                    severity = Severity.INFO
+                                elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
                                     # A capability the server has, not a threat.
                                     severity = Severity.INFO
                                 elif rule_name in NON_BLOCKING_THREAT_RULES:
                                     severity = Severity.MEDIUM
                                 else:
                                     severity = Severity.CRITICAL
-                                    server_code_findings += 1
+                                    blocking_findings += 1
 
                                 findings.append(
                                     Finding(
@@ -201,9 +207,7 @@ class CQ02NoMaliciousPatterns(Control):
             # Unparseable output means the results are unknown, not empty.
             return self.error(f"Failed to parse malicious pattern results: {e}", duration_ms=duration)
 
-        # Only fail on findings in server code, not dependencies
-        # Dependency findings are informational (INFO severity)
-        if server_code_findings > 0:
+        if blocking_findings > 0:
             status = ControlStatus.FAIL
         else:
             status = ControlStatus.PASS

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
@@ -24,22 +24,13 @@ SKIP_DIRS = {"deps", "node_modules", "vendor", "site-packages", ".venv", "venv",
 # able to do is the capability-declaration domain's question, not malware's.
 CAPABILITY_RULE_PREFIX = "capability-"
 
-# Capabilities that are not, on their own, a verdict but have no ordinary reason
-# to appear in a server that wraps an API: reading browser credential stores, or
-# reaching for curl/wget/nc. Reported so they stay visible, not blocking --
-# actually misusing them trips a `threat-*` rule, which does block.
-NOTABLE_CAPABILITY_RULES = {
-    "capability-filesystem-browser",
-    "capability-network-lolbas",
-}
-
 # Threat rules that fire on ordinary MCP server behaviour, reported but not
 # blocking. Reading credentials from the environment is the mechanism the
 # manifest's user_config describes, and calling third-party APIs over TLS is
 # what a server wrapping an API does. Malicious use of either shows up in the
 # rules that describe the malicious part -- exfiltration, obfuscation, spawning
 # a shell -- which stay blocking.
-HIGH_FP_RULES = {
+NON_BLOCKING_THREAT_RULES = {
     "threat-runtime-environment-read",
     "threat-network-outbound-shady-links",
     "threat-runtime-obfuscation-unicode",
@@ -49,10 +40,9 @@ HIGH_FP_RULES = {
 def _is_dependency_path(path: str) -> bool:
     """Whether a tool-reported path points into vendored dependency code.
 
-    Matched on path components rather than substrings: GuardDog reports paths
-    relative to the scanned directory, so a leading-slash pattern like
-    "/node_modules/" silently misses every one of them and the bundle gets
-    charged for findings in code it merely depends on.
+    Reported so a publisher can tell their own code from what they vendor. It
+    deliberately does not affect the verdict: the layout is author-controlled,
+    so a payload dropped into a directory named `vendor` would exempt itself.
     """
     return any(part in SKIP_DIRS for part in PurePosixPath(path).parts)
 
@@ -175,14 +165,16 @@ class CQ02NoMaliciousPatterns(Control):
 
                                 # Per MTF spec, CQ-02 only evaluates server code
                                 # Findings in dependencies are informational only
-                                if in_deps:
-                                    severity = Severity.INFO
-                                elif rule_name in NOTABLE_CAPABILITY_RULES:
-                                    severity = Severity.MEDIUM
-                                elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
+                                # Severity comes from the rule, never from where
+                                # the file sits. A bundle ships and executes the
+                                # code it vendors, so an obfuscated exec or an
+                                # exfiltration pattern is its problem wherever it
+                                # lives -- and a directory whose name the author
+                                # chose is not a boundary anything can rest on.
+                                if rule_name.startswith(CAPABILITY_RULE_PREFIX):
                                     # A capability the server has, not a threat.
                                     severity = Severity.INFO
-                                elif rule_name in HIGH_FP_RULES:
+                                elif rule_name in NON_BLOCKING_THREAT_RULES:
                                     severity = Severity.MEDIUM
                                 else:
                                     severity = Severity.CRITICAL

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
@@ -24,6 +24,13 @@ SKIP_DIRS = {"deps", "node_modules", "vendor", "site-packages", ".venv", "venv",
 # able to do is the capability-declaration domain's question, not malware's.
 CAPABILITY_RULE_PREFIX = "capability-"
 
+# GuardDog's credential-access rule, and it is not "reads a .env": the same rule
+# matches /etc/shadow, .ssh/id_rsa, .aws/credentials, .git-credentials, .npmrc,
+# .pypirc and the browser credential stores. Exempting the rule to allow the
+# .env case would let reading an SSH key pass, so the exemption is gated on
+# which string actually matched.
+CREDENTIAL_READ_RULE = "threat-filesystem-read"
+
 # Threat rules that fire on ordinary MCP server behaviour, reported but not
 # blocking. Reading credentials from the environment is the mechanism the
 # manifest's user_config describes, and calling third-party APIs over TLS is
@@ -32,10 +39,21 @@ CAPABILITY_RULE_PREFIX = "capability-"
 # a shell -- which stay blocking.
 NON_BLOCKING_THREAT_RULES = {
     "threat-runtime-environment-read",
-    "threat-filesystem-read",
     "threat-network-outbound-shady-links",
     "threat-runtime-obfuscation-unicode",
 }
+
+
+def _reads_own_config(match: str | None) -> bool:
+    """Whether a credential-access hit is the server loading its own .env.
+
+    Covers `.env`, `.env.local`, `.env.production` and the like -- how a server
+    reads its own configuration, one layer below reading the environment
+    itself. Every other string this rule matches is someone else's secret.
+    """
+    if not match:
+        return False
+    return PurePosixPath(match.strip().strip("\"'")).name.startswith(".env")
 
 
 def _is_dependency_path(path: str) -> bool:
@@ -180,6 +198,8 @@ class CQ02NoMaliciousPatterns(Control):
                                 elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
                                     # A capability the server has, not a threat.
                                     severity = Severity.INFO
+                                elif rule_name == CREDENTIAL_READ_RULE and _reads_own_config(finding.get("match")):
+                                    severity = Severity.MEDIUM
                                 elif rule_name in NON_BLOCKING_THREAT_RULES:
                                     severity = Severity.MEDIUM
                                 else:

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
@@ -47,13 +47,25 @@ NON_BLOCKING_THREAT_RULES = {
 def _reads_own_config(match: str | None) -> bool:
     """Whether a credential-access hit is the server loading its own .env.
 
-    Covers `.env`, `.env.local`, `.env.production` and the like -- how a server
-    reads its own configuration, one layer below reading the environment
-    itself. Every other string this rule matches is someone else's secret.
+    Covers `.env`, `.env.local` and `.env.production` reached relatively -- how
+    a server reads its own configuration, one layer below reading the
+    environment itself. Every other string this rule matches is someone else's
+    secret, including a `.env` outside the bundle.
     """
     if not match:
         return False
-    return PurePosixPath(match.strip().strip("\"'")).name.startswith(".env")
+    cleaned = match.strip().strip("\"'")
+
+    # A server reaches its own config by a relative path. An absolute or
+    # home-relative one names a file outside the bundle -- /home/someone/.env
+    # is another user's secret however it is spelled.
+    if cleaned.startswith(("/", "~")):
+        return False
+
+    # `.env`, `.env.local`, `.env.production`. Not `.envrc`, which is direnv's
+    # and routinely holds exported credentials.
+    name = PurePosixPath(cleaned).name
+    return name == ".env" or name.startswith(".env.")
 
 
 def _is_dependency_path(path: str) -> bool:
@@ -160,68 +172,67 @@ class CQ02NoMaliciousPatterns(Control):
         blocking_findings = 0
 
         try:
-            if result.stdout.strip():
-                data = json.loads(result.stdout)
+            data = json.loads(result.stdout)
 
-                # GuardDog reports engine failures in-band: it exits zero and
-                # emits a full document whose `errors` map explains that rules
-                # did not run, while `results` sits empty. Non-empty output is
-                # therefore not evidence that anything was analysed, and an
-                # empty `results` under those conditions means "unknown", not
-                # "clean" -- the one answer this control must never guess at.
-                if isinstance(data, dict) and data.get("errors"):
-                    return self.error(
-                        f"GuardDog analysis failed: {json.dumps(data['errors'])[:500]}",
-                        duration_ms=duration,
-                    )
+            # GuardDog reports engine failures in-band: it exits zero and
+            # emits a full document whose `errors` map explains that rules
+            # did not run, while `results` sits empty. Non-empty output is
+            # therefore not evidence that anything was analysed, and an
+            # empty `results` under those conditions means "unknown", not
+            # "clean" -- the one answer this control must never guess at.
+            if isinstance(data, dict) and data.get("errors"):
+                return self.error(
+                    f"GuardDog analysis failed: {json.dumps(data['errors'])[:500]}",
+                    duration_ms=duration,
+                )
 
-                if isinstance(data, dict):
-                    for rule_name, rule_findings in data.get("results", {}).items():
-                        if rule_findings:
-                            for finding in rule_findings:
-                                file_path = finding.get("location", "unknown")
-                                in_deps = _is_dependency_path(file_path)
+            if isinstance(data, dict):
+                for rule_name, rule_findings in data.get("results", {}).items():
+                    if rule_findings:
+                        for finding in rule_findings:
+                            file_path = finding.get("location", "unknown")
+                            in_deps = _is_dependency_path(file_path)
 
-                                # Vendored code is reported but does not block.
-                                # GuardDog's threat rules fire readily on ordinary
-                                # libraries -- PyYAML's loader, pyperclip shelling
-                                # out, dotenv reading a file -- so treating every
-                                # hit in a dependency as malware fails most of the
-                                # fleet. This is a concession to detector
-                                # precision, not a rule about what counts: a
-                                # bundle does ship what it vendors, and a payload
-                                # placed in a directory named `vendor` exempts
-                                # itself. Attributing against the SBOM instead of
-                                # the path is what would close that.
-                                if in_deps:
-                                    severity = Severity.INFO
-                                elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
-                                    # A capability the server has, not a threat.
-                                    severity = Severity.INFO
-                                elif rule_name == CREDENTIAL_READ_RULE and _reads_own_config(finding.get("match")):
-                                    severity = Severity.MEDIUM
-                                elif rule_name in NON_BLOCKING_THREAT_RULES:
-                                    severity = Severity.MEDIUM
-                                else:
-                                    severity = Severity.CRITICAL
-                                    blocking_findings += 1
+                            # Vendored code is reported but does not block.
+                            # GuardDog's threat rules fire readily on ordinary
+                            # libraries -- PyYAML's loader, pyperclip shelling
+                            # out, dotenv reading a file -- so treating every
+                            # hit in a dependency as malware fails most of the
+                            # fleet. This is a concession to detector
+                            # precision, not a rule about what counts: a
+                            # bundle does ship what it vendors, and a payload
+                            # placed in a directory named `vendor` exempts
+                            # itself. Attributing against the SBOM instead of
+                            # the path is what would close that.
+                            if in_deps:
+                                severity = Severity.INFO
+                            elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
+                                # A capability the server has, not a threat.
+                                severity = Severity.INFO
+                            elif rule_name == CREDENTIAL_READ_RULE and _reads_own_config(finding.get("match")):
+                                severity = Severity.MEDIUM
+                            elif rule_name in NON_BLOCKING_THREAT_RULES:
+                                severity = Severity.MEDIUM
+                            else:
+                                severity = Severity.CRITICAL
+                                blocking_findings += 1
 
-                                findings.append(
-                                    Finding(
-                                        id=f"CQ-02-{len(findings):04d}",
-                                        control=self.id,
-                                        severity=severity,
-                                        title=f"Malicious pattern: {rule_name}",
-                                        description=finding.get("message", "Suspicious code pattern detected"),
-                                        file=file_path,
-                                        in_deps=in_deps,
-                                        remediation="Review the code and remove malicious patterns",
-                                        metadata={
-                                            "rule": rule_name,
-                                            "ecosystem": ecosystem,
-                                        },
-                                    )
+                            findings.append(
+                                Finding(
+                                    id=f"CQ-02-{len(findings):04d}",
+                                    control=self.id,
+                                    severity=severity,
+                                    title=f"Malicious pattern: {rule_name}",
+                                    description=finding.get("message", "Suspicious code pattern detected"),
+                                    file=file_path,
+                                    in_deps=in_deps,
+                                    remediation="Review the code and remove malicious patterns",
+                                    metadata={
+                                        "rule": rule_name,
+                                        "ecosystem": ecosystem,
+                                    },
                                 )
+                            )
 
         except json.JSONDecodeError as e:
             # Unparseable output means the results are unknown, not empty.

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq02_malicious.py
@@ -24,6 +24,15 @@ SKIP_DIRS = {"deps", "node_modules", "vendor", "site-packages", ".venv", "venv",
 # able to do is the capability-declaration domain's question, not malware's.
 CAPABILITY_RULE_PREFIX = "capability-"
 
+# Capabilities that are not, on their own, a verdict but have no ordinary reason
+# to appear in a server that wraps an API: reading browser credential stores, or
+# reaching for curl/wget/nc. Reported so they stay visible, not blocking --
+# actually misusing them trips a `threat-*` rule, which does block.
+NOTABLE_CAPABILITY_RULES = {
+    "capability-filesystem-browser",
+    "capability-network-lolbas",
+}
+
 # Threat rules that fire on ordinary MCP server behaviour, reported but not
 # blocking. Reading credentials from the environment is the mechanism the
 # manifest's user_config describes, and calling third-party APIs over TLS is
@@ -168,6 +177,8 @@ class CQ02NoMaliciousPatterns(Control):
                                 # Findings in dependencies are informational only
                                 if in_deps:
                                     severity = Severity.INFO
+                                elif rule_name in NOTABLE_CAPABILITY_RULES:
+                                    severity = Severity.MEDIUM
                                 elif rule_name.startswith(CAPABILITY_RULE_PREFIX):
                                     # A capability the server has, not a threat.
                                     severity = Severity.INFO

--- a/apps/scanner/src/mpak_scanner/job.py
+++ b/apps/scanner/src/mpak_scanner/job.py
@@ -57,7 +57,7 @@ def run_job() -> None:
     logger.info("Starting scan job %s for %s", scan_id, env["BUNDLE_S3_KEY"])
 
     try:
-        import boto3  # type: ignore[unresolved-import]
+        import boto3
 
         s3 = boto3.client("s3", region_name=region)
 

--- a/apps/scanner/tests/test_e2e_bundles.py
+++ b/apps/scanner/tests/test_e2e_bundles.py
@@ -13,6 +13,7 @@ Run:
     uv run pytest -m e2e -v
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -44,8 +45,18 @@ NODE_BUNDLES = [
 
 
 def skip_if_missing(bundle_path: Path) -> None:
-    if not bundle_path.exists():
-        pytest.skip(f"Bundle not found: {bundle_path.name} (run: mpak bundle pull ... -o {bundle_path})")
+    """Skip locally when the corpus is absent, but never in CI.
+
+    These are the only tests that run the real tools against real bundles, and
+    a silent skip is how a regression reaches production with CI green. CI sets
+    MPAK_E2E_REQUIRED so a missing corpus fails loudly instead.
+    """
+    if bundle_path.exists():
+        return
+    message = f"Bundle not found: {bundle_path.name} (run: mpak bundle pull ... -o {bundle_path})"
+    if os.environ.get("MPAK_E2E_REQUIRED"):
+        pytest.fail(message)
+    pytest.skip(message)
 
 
 @pytest.mark.e2e
@@ -114,8 +125,14 @@ class TestFullScan:
         skip_if_missing(bundle)
         report = scan_bundle(bundle)
 
+        # SC-02 is excluded: it reports real CVEs in these bundles' real
+        # dependencies, which are true positives and change as advisories land.
+        # What this guards is the analysis controls inventing findings on
+        # ordinary code, which is the failure mode that has actually bitten.
         critical = []
         for control_id, result in report.all_controls.items():
+            if control_id == "SC-02":
+                continue
             for f in result.findings:
                 if f.severity == Severity.CRITICAL:
                     critical.append(f"{control_id}: {f.title}")
@@ -127,8 +144,14 @@ class TestFullScan:
         skip_if_missing(bundle)
         report = scan_bundle(bundle)
 
+        # SC-02 is excluded: it reports real CVEs in these bundles' real
+        # dependencies, which are true positives and change as advisories land.
+        # What this guards is the analysis controls inventing findings on
+        # ordinary code, which is the failure mode that has actually bitten.
         critical = []
         for control_id, result in report.all_controls.items():
+            if control_id == "SC-02":
+                continue
             for f in result.findings:
                 if f.severity == Severity.CRITICAL:
                     critical.append(f"{control_id}: {f.title}")

--- a/apps/scanner/tests/test_e2e_bundles.py
+++ b/apps/scanner/tests/test_e2e_bundles.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from mpak_scanner import scan_bundle
+from mpak_scanner import SecurityReport, scan_bundle
 from mpak_scanner.models import ControlStatus, Severity
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -44,12 +44,31 @@ NODE_BUNDLES = [
 ]
 
 
+# SC-02 reports real CVEs in these bundles' real dependencies. Those are true
+# positives and they move as advisories land, so they are not what this suite
+# guards -- which is the analysis controls inventing findings on ordinary code.
+CONTROLS_WITH_MOVING_TRUE_POSITIVES = {"SC-02"}
+
+
+def critical_findings_excluding_true_positives(report: SecurityReport) -> list[str]:
+    """Critical findings that would indicate a false positive, not a real CVE."""
+    return [
+        f"{control_id}: {f.title}"
+        for control_id, result in report.all_controls.items()
+        if control_id not in CONTROLS_WITH_MOVING_TRUE_POSITIVES
+        for f in result.findings
+        if f.severity == Severity.CRITICAL
+    ]
+
+
 def skip_if_missing(bundle_path: Path) -> None:
-    """Skip locally when the corpus is absent, but never in CI.
+    """Skip when the corpus is absent, unless MPAK_E2E_REQUIRED is set.
 
     These are the only tests that run the real tools against real bundles, and
-    a silent skip is how a regression reaches production with CI green. CI sets
-    MPAK_E2E_REQUIRED so a missing corpus fails loudly instead.
+    a silent skip is how a regression reaches production with CI green. Setting
+    MPAK_E2E_REQUIRED turns a missing corpus into a failure. Nothing sets it
+    yet: running this suite in CI also needs the external toolchain, which the
+    runner does not have. See #137.
     """
     if bundle_path.exists():
         return
@@ -125,17 +144,7 @@ class TestFullScan:
         skip_if_missing(bundle)
         report = scan_bundle(bundle)
 
-        # SC-02 is excluded: it reports real CVEs in these bundles' real
-        # dependencies, which are true positives and change as advisories land.
-        # What this guards is the analysis controls inventing findings on
-        # ordinary code, which is the failure mode that has actually bitten.
-        critical = []
-        for control_id, result in report.all_controls.items():
-            if control_id == "SC-02":
-                continue
-            for f in result.findings:
-                if f.severity == Severity.CRITICAL:
-                    critical.append(f"{control_id}: {f.title}")
+        critical = critical_findings_excluding_true_positives(report)
         assert critical == [], f"Critical findings on {bundle.name}: {critical}"
 
     @pytest.mark.parametrize("bundle", NODE_BUNDLES)
@@ -144,17 +153,7 @@ class TestFullScan:
         skip_if_missing(bundle)
         report = scan_bundle(bundle)
 
-        # SC-02 is excluded: it reports real CVEs in these bundles' real
-        # dependencies, which are true positives and change as advisories land.
-        # What this guards is the analysis controls inventing findings on
-        # ordinary code, which is the failure mode that has actually bitten.
-        critical = []
-        for control_id, result in report.all_controls.items():
-            if control_id == "SC-02":
-                continue
-            for f in result.findings:
-                if f.severity == Severity.CRITICAL:
-                    critical.append(f"{control_id}: {f.title}")
+        critical = critical_findings_excluding_true_positives(report)
         assert critical == [], f"Critical findings on {bundle.name}: {critical}"
 
     @pytest.mark.parametrize("bundle", ALL_BUNDLES)

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -2653,13 +2653,6 @@ class TestCQ02GuardDogThreeTaxonomy:
         assert result.status == ControlStatus.PASS
         assert all(f.severity == Severity.INFO for f in result.findings)
 
-    def test_env_file_read_is_reported_not_blocking(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Loading a .env is how a server reads credentials, one layer below
-        reading the environment itself, which is already non-blocking."""
-        result = self._run(tmp_path, monkeypatch, "threat-filesystem-read", "build/config.js")
-        assert result.status == ControlStatus.PASS
-        assert any(f.severity == Severity.MEDIUM for f in result.findings)
-
     def test_capability_rule_is_informational(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """`capability-*` states what the code can do, which is not a verdict.
 
@@ -2748,3 +2741,54 @@ class TestCQ02AgainstRealGuardDog:
             f"a dependency's code failed the bundle: {[(f.severity.value, f.file) for f in result.findings]}"
         )
         assert any(f.in_deps for f in result.findings)
+
+
+class TestCQ02CredentialAccess:
+    """`threat-filesystem-read` is GuardDog's credential-access rule.
+
+    It matches /etc/shadow, .ssh/id_rsa, .aws/credentials, .npmrc and the
+    browser credential stores as well as .env. Exempting the rule so a server
+    can load its own config would exempt reading someone else's secret, so the
+    exemption is gated on which string matched.
+    """
+
+    @staticmethod
+    def _run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, match: str):
+        (tmp_path / "server.js").write_text("console.log(1);\n")
+
+        from mpak_scanner.controls.code_quality import cq02_malicious
+
+        payload = json.dumps(
+            {
+                "issues": 1,
+                "errors": {},
+                "results": {"threat-filesystem-read": [{"location": "server.js:1", "message": "m", "match": match}]},
+            }
+        )
+
+        def fake_run(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq02_malicious.subprocess, "run", fake_run)
+        return cq02_malicious.CQ02NoMaliciousPatterns().run(tmp_path, {})
+
+    @pytest.mark.parametrize("match", ['".env"', '".env.local"', '"../.env"'])
+    def test_reading_own_config_is_not_blocking(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, match: str
+    ) -> None:
+        """How a server loads its own configuration."""
+        result = self._run(tmp_path, monkeypatch, match)
+        assert result.status == ControlStatus.PASS
+        assert any(f.severity == Severity.MEDIUM for f in result.findings)
+
+    @pytest.mark.parametrize(
+        "match",
+        [".ssh/id_rsa", ".aws/credentials", ".npmrc", "/etc/shadow", "Google/Chrome/User Data"],
+    )
+    def test_reading_someone_elses_secret_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, match: str
+    ) -> None:
+        """The hole this closes: the rule-wide exemption passed all of these."""
+        result = self._run(tmp_path, monkeypatch, match)
+        assert result.status == ControlStatus.FAIL
+        assert any(f.severity == Severity.CRITICAL for f in result.findings)

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -2637,17 +2637,28 @@ class TestCQ02GuardDogThreeTaxonomy:
         assert all(f.severity == Severity.INFO for f in result.findings)
         assert all(f.in_deps for f in result.findings)
 
-    def test_real_threat_in_a_dependency_still_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A bundle ships and runs what it vendors, so it answers for it."""
-        result = self._run(tmp_path, monkeypatch, "threat-process-cryptomining", "node_modules/some-dep/index.js")
-        assert result.status == ControlStatus.FAIL
-
-    def test_threat_in_an_author_named_directory_still_fails(
+    def test_threat_in_a_dependency_is_reported_not_blocking(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The bypass this closes: `vendor/` is a convention, not a boundary."""
-        result = self._run(tmp_path, monkeypatch, "threat-network-exfiltration", "vendor/index.js")
-        assert result.status == ControlStatus.FAIL
+        """Vendored code is reported, not charged to the bundle.
+
+        GuardDog's threat rules fire on ordinary libraries -- PyYAML's loader,
+        pyperclip shelling out, dotenv reading a file -- so blocking on them
+        fails most of the fleet. That is a concession to detector precision and
+        it leaves a real gap: the path is author-controlled, so a payload in a
+        directory named `vendor` exempts itself. Closing it needs attribution
+        against the SBOM rather than a path convention.
+        """
+        result = self._run(tmp_path, monkeypatch, "threat-process-cryptomining", "node_modules/some-dep/index.js")
+        assert result.status == ControlStatus.PASS
+        assert all(f.severity == Severity.INFO for f in result.findings)
+
+    def test_env_file_read_is_reported_not_blocking(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loading a .env is how a server reads credentials, one layer below
+        reading the environment itself, which is already non-blocking."""
+        result = self._run(tmp_path, monkeypatch, "threat-filesystem-read", "build/config.js")
+        assert result.status == ControlStatus.PASS
+        assert any(f.severity == Severity.MEDIUM for f in result.findings)
 
     def test_capability_rule_is_informational(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """`capability-*` states what the code can do, which is not a verdict.
@@ -2716,11 +2727,11 @@ class TestCQ02AgainstRealGuardDog:
         assert result.status == ControlStatus.FAIL
         assert any(f.severity == Severity.CRITICAL for f in result.findings)
 
-    def test_threat_inside_a_dependency_fails_the_bundle(self, tmp_path: Path) -> None:
-        """A bundle ships and executes what it vendors, so it answers for it.
+    def test_threat_inside_a_dependency_is_reported_not_blocking(self, tmp_path: Path) -> None:
+        """Real GuardDog output through the dependency path, end to end.
 
-        Attributing by directory let a payload exempt itself by sitting in one
-        named `vendor`; the rule decides the verdict, not the location.
+        The matcher has to recognise the relative paths GuardDog reports, or a
+        bundle gets charged for the code it merely depends on.
         """
         (tmp_path / "server.js").write_text('console.log("hello");\n')
         vendored = tmp_path / "node_modules" / "some-dep"
@@ -2733,6 +2744,7 @@ class TestCQ02AgainstRealGuardDog:
 
         result = CQ02NoMaliciousPatterns().run(tmp_path, {})
 
-        assert result.status == ControlStatus.FAIL
-        # Still reported as vendored, so a publisher can see whose code it is.
-        assert any(f.in_deps and f.severity == Severity.CRITICAL for f in result.findings)
+        assert result.status == ControlStatus.PASS, (
+            f"a dependency's code failed the bundle: {[(f.severity.value, f.file) for f in result.findings]}"
+        )
+        assert any(f.in_deps for f in result.findings)

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -2623,20 +2623,31 @@ class TestCQ02GuardDogThreeTaxonomy:
         monkeypatch.setattr(cq02_malicious.subprocess, "run", fake_run)
         return cq02_malicious.CQ02NoMaliciousPatterns().run(self._bundle(tmp_path), {})
 
-    def test_dependency_finding_does_not_fail_the_bundle(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """GuardDog reports relative paths, so `/node_modules/` never matched.
-
-        A bundle was being charged for patterns in the SDK it depends on.
-        """
+    def test_capability_in_a_dependency_does_not_fail_the_bundle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The original false positive: capability rules inside the MCP SDK."""
         result = self._run(
             tmp_path,
             monkeypatch,
-            "threat-process-cryptomining",
+            "capability-process-spawn",
             "node_modules/@modelcontextprotocol/sdk/dist/index.js",
         )
         assert result.status == ControlStatus.PASS
         assert all(f.severity == Severity.INFO for f in result.findings)
         assert all(f.in_deps for f in result.findings)
+
+    def test_real_threat_in_a_dependency_still_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bundle ships and runs what it vendors, so it answers for it."""
+        result = self._run(tmp_path, monkeypatch, "threat-process-cryptomining", "node_modules/some-dep/index.js")
+        assert result.status == ControlStatus.FAIL
+
+    def test_threat_in_an_author_named_directory_still_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bypass this closes: `vendor/` is a convention, not a boundary."""
+        result = self._run(tmp_path, monkeypatch, "threat-network-exfiltration", "vendor/index.js")
+        assert result.status == ControlStatus.FAIL
 
     def test_capability_rule_is_informational(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """`capability-*` states what the code can do, which is not a verdict.
@@ -2705,11 +2716,11 @@ class TestCQ02AgainstRealGuardDog:
         assert result.status == ControlStatus.FAIL
         assert any(f.severity == Severity.CRITICAL for f in result.findings)
 
-    def test_threat_inside_a_dependency_does_not_fail_the_bundle(self, tmp_path: Path) -> None:
-        """A bundle is not answerable for patterns in the code it vendors.
+    def test_threat_inside_a_dependency_fails_the_bundle(self, tmp_path: Path) -> None:
+        """A bundle ships and executes what it vendors, so it answers for it.
 
-        This is the path-matching half: GuardDog reports relative paths, so the
-        dependency check has to recognise them as such.
+        Attributing by directory let a payload exempt itself by sitting in one
+        named `vendor`; the rule decides the verdict, not the location.
         """
         (tmp_path / "server.js").write_text('console.log("hello");\n')
         vendored = tmp_path / "node_modules" / "some-dep"
@@ -2722,7 +2733,6 @@ class TestCQ02AgainstRealGuardDog:
 
         result = CQ02NoMaliciousPatterns().run(tmp_path, {})
 
-        assert result.status == ControlStatus.PASS, (
-            f"a dependency's code failed the bundle: {[(f.severity.value, f.file) for f in result.findings]}"
-        )
-        assert all(f.in_deps for f in result.findings if f.severity != Severity.INFO)
+        assert result.status == ControlStatus.FAIL
+        # Still reported as vendored, so a publisher can see whose code it is.
+        assert any(f.in_deps and f.severity == Severity.CRITICAL for f in result.findings)

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -2792,3 +2792,15 @@ class TestCQ02CredentialAccess:
         result = self._run(tmp_path, monkeypatch, match)
         assert result.status == ControlStatus.FAIL
         assert any(f.severity == Severity.CRITICAL for f in result.findings)
+
+    @pytest.mark.parametrize("match", [".envrc", "/home/victim/.env", '"~/.env"'])
+    def test_env_named_file_outside_the_bundle_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, match: str
+    ) -> None:
+        """A `.env` somewhere else is still someone else's secret.
+
+        `.envrc` is direnv's and routinely holds exported credentials; an
+        absolute or home-relative path names a file the bundle does not own.
+        """
+        result = self._run(tmp_path, monkeypatch, match)
+        assert result.status == ControlStatus.FAIL

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -2585,3 +2585,83 @@ class TestToolCrashDoesNotSilentlyPass:
 
         result = cq01_secrets.CQ01NoEmbeddedSecrets().run(tmp_path, {})
         assert result.status == ControlStatus.ERROR
+
+
+class TestCQ02GuardDogThreeTaxonomy:
+    """GuardDog 3.x renamed and re-scoped its rules; CQ-02 reads that taxonomy.
+
+    The real failure this guards: every finding in the ipgeolocation bundle came
+    back CRITICAL, including ones inside the official MCP SDK, because
+    dependency paths were not recognised and capability rules were read as
+    threats. A legitimate server cannot be certified as containing malware.
+    """
+
+    @staticmethod
+    def _bundle(tmp_path: Path) -> Path:
+        (tmp_path / "server.js").write_text("console.log(1);\n")
+        return tmp_path
+
+    @staticmethod
+    def _guarddog_output(rule: str, location: str) -> str:
+        return json.dumps(
+            {
+                "package": "x",
+                "issues": 1,
+                "errors": {},
+                "results": {rule: [{"location": location, "message": f"{rule} matched"}]},
+            }
+        )
+
+    def _run(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, rule: str, location: str):
+        from mpak_scanner.controls.code_quality import cq02_malicious
+
+        payload = self._guarddog_output(rule, location)
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq02_malicious.subprocess, "run", fake_run)
+        return cq02_malicious.CQ02NoMaliciousPatterns().run(self._bundle(tmp_path), {})
+
+    def test_dependency_finding_does_not_fail_the_bundle(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GuardDog reports relative paths, so `/node_modules/` never matched.
+
+        A bundle was being charged for patterns in the SDK it depends on.
+        """
+        result = self._run(
+            tmp_path,
+            monkeypatch,
+            "threat-process-cryptomining",
+            "node_modules/@modelcontextprotocol/sdk/dist/index.js",
+        )
+        assert result.status == ControlStatus.PASS
+        assert all(f.severity == Severity.INFO for f in result.findings)
+        assert all(f.in_deps for f in result.findings)
+
+    def test_capability_rule_is_informational(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`capability-*` states what the code can do, which is not a verdict.
+
+        A server that calls the API it wraps trips this by existing.
+        """
+        result = self._run(tmp_path, monkeypatch, "capability-network-outbound", "dist/client.js")
+        assert result.status == ControlStatus.PASS
+        assert any(f.severity == Severity.INFO for f in result.findings)
+
+    def test_reading_environment_is_reported_not_blocking(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credentials arrive through the environment by design in MCP."""
+        result = self._run(tmp_path, monkeypatch, "threat-runtime-environment-read", "dist/config.js")
+        assert result.status == ControlStatus.PASS
+        assert any(f.severity == Severity.MEDIUM for f in result.findings)
+
+    def test_real_threat_in_server_code_still_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The control must still catch what it exists to catch."""
+        result = self._run(tmp_path, monkeypatch, "threat-network-exfiltration", "dist/evil.js")
+        assert result.status == ControlStatus.FAIL
+        assert any(f.severity == Severity.CRITICAL for f in result.findings)
+
+    def test_obfuscation_in_server_code_still_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Obfuscation is a threat verdict, not a capability."""
+        result = self._run(tmp_path, monkeypatch, "threat-runtime-obfuscation-base64exec", "dist/a.js")
+        assert result.status == ControlStatus.FAIL

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -2665,3 +2665,64 @@ class TestCQ02GuardDogThreeTaxonomy:
         """Obfuscation is a threat verdict, not a capability."""
         result = self._run(tmp_path, monkeypatch, "threat-runtime-obfuscation-base64exec", "dist/a.js")
         assert result.status == ControlStatus.FAIL
+
+
+class TestCQ02AgainstRealGuardDog:
+    """Runs the real analyser, because mocks cannot see a taxonomy change.
+
+    Every other CQ-02 test hand-authors GuardDog's output, so they stay green
+    when GuardDog renames or re-scopes its rules -- which is exactly how this
+    control came to certify a legitimate bundle as containing critical malware.
+    These deliberately do not skip when the tool is missing: a silent skip
+    would restore the blind spot they exist to remove.
+    """
+
+    def test_ordinary_server_behaviour_does_not_fail(self, tmp_path: Path) -> None:
+        """Reading a key from the environment and calling an API is the job."""
+        (tmp_path / "server.js").write_text(
+            'const k = process.env.API_KEY;\nfetch("https://api.example.com?k=" + k);\n'
+        )
+
+        from mpak_scanner.controls.code_quality import CQ02NoMaliciousPatterns
+
+        result = CQ02NoMaliciousPatterns().run(tmp_path, {})
+
+        assert result.status == ControlStatus.PASS, (
+            f"a plain API client failed CQ-02: {[(f.severity.value, f.title) for f in result.findings]}"
+        )
+        assert not any(f.severity == Severity.CRITICAL for f in result.findings)
+
+    def test_obfuscated_execution_still_fails(self, tmp_path: Path) -> None:
+        """The control must still catch what it exists to catch."""
+        (tmp_path / "server.js").write_text(
+            'const p = Buffer.from("Y29uc29sZS5sb2coMSk=", "base64").toString();\neval(p);\n'
+        )
+
+        from mpak_scanner.controls.code_quality import CQ02NoMaliciousPatterns
+
+        result = CQ02NoMaliciousPatterns().run(tmp_path, {})
+
+        assert result.status == ControlStatus.FAIL
+        assert any(f.severity == Severity.CRITICAL for f in result.findings)
+
+    def test_threat_inside_a_dependency_does_not_fail_the_bundle(self, tmp_path: Path) -> None:
+        """A bundle is not answerable for patterns in the code it vendors.
+
+        This is the path-matching half: GuardDog reports relative paths, so the
+        dependency check has to recognise them as such.
+        """
+        (tmp_path / "server.js").write_text('console.log("hello");\n')
+        vendored = tmp_path / "node_modules" / "some-dep"
+        vendored.mkdir(parents=True)
+        (vendored / "index.js").write_text(
+            'const p = Buffer.from("Y29uc29sZS5sb2coMSk=", "base64").toString();\neval(p);\n'
+        )
+
+        from mpak_scanner.controls.code_quality import CQ02NoMaliciousPatterns
+
+        result = CQ02NoMaliciousPatterns().run(tmp_path, {})
+
+        assert result.status == ControlStatus.PASS, (
+            f"a dependency's code failed the bundle: {[(f.severity.value, f.file) for f in result.findings]}"
+        )
+        assert all(f.in_deps for f in result.findings if f.severity != Severity.INFO)

--- a/apps/scanner/uv.lock
+++ b/apps/scanner/uv.lock
@@ -21,49 +21,46 @@ wheels = [
 ]
 
 [[package]]
-name = "boltons"
-version = "21.0.0"
+name = "bandit"
+version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/1f/6c0608d86e0fc77c982a2923ece80eef85f091f2332fc13cbce41d70d502/boltons-21.0.0.tar.gz", hash = "sha256:65e70a79a731a7fe6e98592ecfb5ccf2115873d01dbc576079874629e5c90f13", size = 180201, upload-time = "2021-05-17T01:20:17.802Z" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/a7/1a31561d10a089fcb46fe286766dd4e053a12f6e23b4fd1c26478aff2475/boltons-21.0.0-py2.py3-none-any.whl", hash = "sha256:b9bb7b58b2b420bbe11a6025fdef6d3e5edc9f76a42fb467afe7ca212ef9948b", size = 193723, upload-time = "2021-05-17T01:20:20.023Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
 ]
 
 [[package]]
 name = "boto3"
-version = "1.42.46"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/87/1ccd436a6815c18107aa74aa2b7b2745dc5a1db83cf58afc591df2755775/boto3-1.42.46.tar.gz", hash = "sha256:c8c82ab34dd8d2d4d93a562d0e75fca164efa644651d3ccddb0f4aa88a481b38", size = 112795, upload-time = "2026-02-10T20:38:10.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/93/5f98e422ced57a359e3b7827ab79b359d67456abb9c5840b0c5eb7b90e6b/boto3-1.43.52.tar.gz", hash = "sha256:3da09a393c050906d407023bee5fb5b5fb333378513af1a1a51159db870b572f", size = 112680, upload-time = "2026-07-20T19:31:28.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/41/978d749a6604bf93e05e8be56db07eb1402ffe576e1bb9b65aa391ebcb73/boto3-1.42.46-py3-none-any.whl", hash = "sha256:679cf4930e559621653bbd1439cf6e93b138cbaf46e36e5d7d95319999b7a356", size = 140606, upload-time = "2026-02-10T20:38:08.175Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/57/31e6f45c3e236273f9f83f047ae579a90c4be8c6dc1b8366d63a6dcd9841/boto3-1.43.52-py3-none-any.whl", hash = "sha256:1af1950c2b2400267c93d971d588367fc73554e02b4f435a50a5e930a7c93526", size = 140026, upload-time = "2026-07-20T19:31:26.247Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.46"
+version = "1.43.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/2d/6f6101f567a69c3b2ebe3f1f81bfd56eda9d5f6f466d0d919293499ab050/botocore-1.42.46.tar.gz", hash = "sha256:fc290b33aba6e271f627c4f46b8bcebfa1a94e19157d396732da417404158c01", size = 14948751, upload-time = "2026-02-10T20:37:58.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/18/f6f02b1acea9a7c42571813ad4c3e19460206e67ca99af402b7ae3d7584d/botocore-1.43.52.tar.gz", hash = "sha256:3c25e11796ae6e295f1cc3a7760e808c26c432cd580d6a608f32da24715c389b", size = 15717429, upload-time = "2026-07-20T19:31:17.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/88/5c2f4e65fe8dba7709a219b768e5ac89a112c6dde9527a5009cb82ee9124/botocore-1.42.46-py3-none-any.whl", hash = "sha256:f7459fcf586f38a3b0a242a172d3332141c770a3f5767bbb21e79d810db95d75", size = 14622519, upload-time = "2026-02-10T20:37:54.223Z" },
-]
-
-[[package]]
-name = "bracex"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e8/99f83445500c565e1850b20d510821d1eb635283171573340aa310d478b5/botocore-1.43.52-py3-none-any.whl", hash = "sha256:43715e971b306f86d5918b3b728ec62aae3f4be49e1606058ef1f0b87dcbad9e", size = 15402564, upload-time = "2026-07-20T19:31:13.936Z" },
 ]
 
 [[package]]
@@ -163,26 +160,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
-]
-
-[[package]]
-name = "click-option-group"
-version = "0.5.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/ff/d291d66595b30b83d1cb9e314b2c9be7cfc7327d4a0d40a15da2416ea97b/click_option_group-0.5.9.tar.gz", hash = "sha256:f94ed2bc4cf69052e0f29592bd1e771a1789bd7bfc482dd0bc482134aff95823", size = 22222, upload-time = "2025-10-09T09:38:01.474Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/45/54bb2d8d4138964a94bef6e9afe48b0be4705ba66ac442ae7d8a8dc4ffef/click_option_group-0.5.9-py3-none-any.whl", hash = "sha256:ad2599248bd373e2e19bec5407967c3eec1d0d4fc4a5e77b08a0481e75991080", size = 11553, upload-time = "2025-10-09T09:38:00.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -273,90 +258,75 @@ wheels = [
 ]
 
 [[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "deprecated"
-version = "1.3.1"
+name = "cryptography"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
 name = "disposable-email-domains"
-version = "0.0.120"
+version = "0.0.214"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/70/9791b423de4a75ecbf8d82409998977fda601d9cc35c5ca99c6e5fb043bc/disposable_email_domains-0.0.120.tar.gz", hash = "sha256:a0d205fe1947223922cf6bdfce6dde90f1776344d7ab9330c67902da3baa4dda", size = 51951, upload-time = "2025-03-11T01:56:04.819Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/56/afd39187878a8b67bbd382791c6a80c2f67684c021b71b2f3bb3221dd431/disposable_email_domains-0.0.214.tar.gz", hash = "sha256:ff2508583769b71c27bd9d529fdbd4e7cd45d4df8aa15da0dea9357848d81f8d", size = 96247, upload-time = "2026-07-06T10:58:43.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/65/ee0d3160de1704d6ddf76e16ae1b08e6236c8eb2cceb4be2bc36373e19fb/disposable_email_domains-0.0.120-py2.py3-none-any.whl", hash = "sha256:9bac4af1ac4c507da9914a71294da4f55732969225aa97e2f35ae7cd25dc67eb", size = 26582, upload-time = "2025-03-11T01:56:03.033Z" },
-]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
-]
-
-[[package]]
-name = "face"
-version = "24.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boltons" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/79/2484075a8549cd64beae697a8f664dee69a5ccf3a7439ee40c8f93c1978a/face-24.0.0.tar.gz", hash = "sha256:611e29a01ac5970f0077f9c577e746d48c082588b411b33a0dd55c4d872949f6", size = 62732, upload-time = "2024-11-02T05:24:26.095Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/47/21867c2e5fd006c8d36a560df9e32cb4f1f566b20c5dd41f5f8a2124f7de/face-24.0.0-py3-none-any.whl", hash = "sha256:0e2c17b426fa4639a4e77d1de9580f74a98f4869ba4c7c8c175b810611622cd3", size = 54742, upload-time = "2024-11-02T05:24:24.939Z" },
-]
-
-[[package]]
-name = "glom"
-version = "22.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "boltons" },
-    { name = "face" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/d1/69432deefa6f5283ec75b246d0540097ae26f618b915519ee3824c4c5dd6/glom-22.1.0.tar.gz", hash = "sha256:1510c6587a8f9c64a246641b70033cbc5ebde99f02ad245693678038e821aeb5", size = 189738, upload-time = "2022-01-24T09:34:04.874Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/e8/68e274b2a30e1fdfd25bdc27194382be3f233929c8f727c0440d58ac074f/glom-22.1.0-py2.py3-none-any.whl", hash = "sha256:5339da206bf3532e01a83a35aca202960ea885156986d190574b779598e9e772", size = 100687, upload-time = "2022-01-24T09:34:02.391Z" },
-]
-
-[[package]]
-name = "googleapis-common-protos"
-version = "1.72.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e0/78eefe66ea5ab7d644804300af47f6ea9b9bd99321c77a0a3397894f8310/disposable_email_domains-0.0.214-py3-none-any.whl", hash = "sha256:7f2aab40bf95ba56f6c660d76b5489323fc124e624131e7817d7cbbbc190bd36", size = 49565, upload-time = "2026-07-06T10:58:41.723Z" },
 ]
 
 [[package]]
 name = "guarddog"
-version = "2.7.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "boto3" },
     { name = "click" },
     { name = "configparser" },
     { name = "disposable-email-domains" },
+    { name = "nono-py" },
+    { name = "packaging" },
     { name = "prettytable" },
     { name = "pygit2" },
     { name = "python-dateutil" },
@@ -364,15 +334,15 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "semantic-version" },
-    { name = "semgrep" },
     { name = "tarsafe" },
     { name = "termcolor" },
+    { name = "typing-extensions" },
     { name = "urllib3" },
     { name = "yara-python" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/b4/8da2b10c35f3fe4767ea4ef7efa1a3b40b4dcea13be63306312b8a54fcde/guarddog-2.7.0.tar.gz", hash = "sha256:4674533d04f2be379e72ca2ca02ab33d81455bdf8ed573f876d44ebefd48f5bc", size = 292134, upload-time = "2025-10-03T15:38:56.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/b6/51524d448f106d3897bbd8ac1bf8be08ba5a6a31d5f3577388955d929198/guarddog-3.1.0.tar.gz", hash = "sha256:0b2ba4b16f05b558516b5b45fb2ed6f8eae6d85ad2d1b08dde03cb17053d559d", size = 279373, upload-time = "2026-07-08T15:42:35.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/78/baf19ab1499fd05b9f94bfe7f15cd6e85287e56b5f28258b139cf54856c2/guarddog-2.7.0-py3-none-any.whl", hash = "sha256:0c9be6299f9dd436f69dbafac753c498b7d403b4a5277cd060efc2db26da9325", size = 339935, upload-time = "2025-10-03T15:38:54.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/34/989428df4a2221dc6873944b23efa1e91bf10d49f4a1fcca9b1ceb6ecf12/guarddog-3.1.0-py3-none-any.whl", hash = "sha256:80572d0dfccb9028a78c0a61e66d54b95ea71b335b105b54c97955786fc00846", size = 342169, upload-time = "2026-07-08T15:42:33.679Z" },
 ]
 
 [[package]]
@@ -382,18 +352,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/fc/c4e6078d21fc4fa56300a241b87eae76766aa380a23fc450fc85bb7bf547/importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2", size = 52120, upload-time = "2024-03-20T19:51:32.429Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570", size = 24409, upload-time = "2024-03-20T19:51:30.241Z" },
 ]
 
 [[package]]
@@ -486,6 +444,7 @@ job = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "guarddog" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -509,7 +468,8 @@ provides-extras = ["dev", "job"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "guarddog", specifier = ">=2.7.0" },
+    { name = "bandit", specifier = "==1.9.4" },
+    { name = "guarddog", specifier = "==3.1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "ruff", specifier = ">=0.9.0" },
@@ -517,122 +477,23 @@ dev = [
 ]
 
 [[package]]
-name = "opentelemetry-api"
-version = "1.25.0"
+name = "nono-py"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated" },
-    { name = "importlib-metadata" },
+    { name = "cryptography" },
+    { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/0d/10357006dc10fc65f7c7b46c18232e466e355f9e606ac461cfc7193b4cbe/opentelemetry_api-1.25.0.tar.gz", hash = "sha256:77c4985f62f2614e42ce77ee4c9da5fa5f0bc1e1821085e9a47533a9323ae869", size = 60383, upload-time = "2024-05-31T01:40:38.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/30b403fc7f875155134ce0568d155256a35c1a5acbbcb1f6b666729f3222/nono_py-0.14.0.tar.gz", hash = "sha256:d310d3b9a6342e3222a3b199e483744603fa5174b0aee707372d4e11f45592c0", size = 275364, upload-time = "2026-07-20T19:41:19.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/b2/4bc5e52c9a23df0ac17dbb23923e609a8269cd67000a712b4f5bcfae1490/opentelemetry_api-1.25.0-py3-none-any.whl", hash = "sha256:757fa1aa020a0f8fa139f8959e53dec2051cc26b832e76fa839a6d76ecefd737", size = 59910, upload-time = "2024-05-31T01:40:00.911Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-proto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/a7/85ffaaacd712e4634fa1c56cbf79a02cf90b8a178fe1eee2cabfb0b7f44d/opentelemetry_exporter_otlp_proto_common-1.25.0.tar.gz", hash = "sha256:c93f4e30da4eee02bacd1e004eb82ce4da143a2f8e15b987a9f603e0a85407d3", size = 17152, upload-time = "2024-05-31T01:40:42.259Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/02/74ac6619eec78c82a923324f916d3eccd2f2254cf4270b669e96b76bf717/opentelemetry_exporter_otlp_proto_common-1.25.0-py3-none-any.whl", hash = "sha256:15637b7d580c2675f70246563363775b4e6de947871e01d0f4e3881d1848d693", size = 17762, upload-time = "2024-05-31T01:40:13.172Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "deprecated" },
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/d9/1c3c518853c27d323a46813d3e99d601959ca2c6963d5217fe2110f0d579/opentelemetry_exporter_otlp_proto_http-1.25.0.tar.gz", hash = "sha256:9f8723859e37c75183ea7afa73a3542f01d0fd274a5b97487ea24cb683d7d684", size = 14048, upload-time = "2024-05-31T01:40:43.749Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/b9/a47734f7c5a45619d8c64c227f119092b4679b2c49d37116fda7c0fc4573/opentelemetry_exporter_otlp_proto_http-1.25.0-py3-none-any.whl", hash = "sha256:2eca686ee11b27acd28198b3ea5e5863a53d1266b91cda47c839d95d5e0541a6", size = 16790, upload-time = "2024-05-31T01:40:16.649Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation"
-version = "0.46b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "setuptools" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/20/0a5d980843e048e9516443a91c63a559b40e5d50a730e73e72a5bde727fd/opentelemetry_instrumentation-0.46b0.tar.gz", hash = "sha256:974e0888fb2a1e01c38fbacc9483d024bb1132aad92d6d24e2e5543887a7adda", size = 24048, upload-time = "2024-05-31T16:17:29.807Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/e5/d6fff0a6f6fbddf03c7fb48ab47925581c4f1a8268f9ad98e5ea4a8b90a5/opentelemetry_instrumentation-0.46b0-py3-none-any.whl", hash = "sha256:89cd721b9c18c014ca848ccd11181e6b3fd3f6c7669e35d59c48dc527408c18b", size = 29108, upload-time = "2024-05-31T16:16:14.042Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-requests"
-version = "0.46b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/28/5b5e9fb74639e47f026a3fd6550bba965ca18b316a8178907540e711855c/opentelemetry_instrumentation_requests-0.46b0.tar.gz", hash = "sha256:ef0ad63bfd0d52631daaf7d687e763dbd89b465f5cb052f12a4e67e5e3d181e4", size = 13709, upload-time = "2024-05-31T16:18:08.594Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/42/5eee8720eccd4b94dd3d4908364785db8b22c9ae512ee47caff29064ca4c/opentelemetry_instrumentation_requests-0.46b0-py3-none-any.whl", hash = "sha256:a8c2472800d8686f3f286cd524b8746b386154092e85a791ba14110d1acc9b81", size = 12170, upload-time = "2024-05-31T16:17:07.341Z" },
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/3c/28c9ce40eb8ab287471af81659089ca98ef4f7ce289669e23b19c29f24a8/opentelemetry_proto-1.25.0.tar.gz", hash = "sha256:35b6ef9dc4a9f7853ecc5006738ad40443701e52c26099e197895cbda8b815a3", size = 35062, upload-time = "2024-05-31T01:40:52.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ae/d6b5f11ecbffafe8b6d54130fed0cc78aad3711e00074d63a7359d6dcf3b/opentelemetry_proto-1.25.0-py3-none-any.whl", hash = "sha256:f07e3341c78d835d9b86665903b199893befa5e98866f63d22b00d0b7ca4972f", size = 52450, upload-time = "2024-05-31T01:40:30.987Z" },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/3c/77076b77f1d73141adc119f62370ec9456ef314ba0b4e7072e3775c36ef7/opentelemetry_sdk-1.25.0.tar.gz", hash = "sha256:ce7fc319c57707ef5bf8b74fb9f8ebdb8bfafbe11898410e0d2a761d08a98ec7", size = 141042, upload-time = "2024-05-31T01:40:53.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/b2/729a959a8aa032bce246c791f977161099ab60fb0188408ccec1bf283b00/opentelemetry_sdk-1.25.0-py3-none-any.whl", hash = "sha256:d97ff7ec4b351692e9d5a15af570c693b8715ad78b8aafbec5c7100fe966b4c9", size = 107028, upload-time = "2024-05-31T01:40:33.281Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.46b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/ea/a4a5277247b3d2ed2e23a58b0d509c2eafa4ebb56038ba5b23c0f9ea6242/opentelemetry_semantic_conventions-0.46b0.tar.gz", hash = "sha256:fbc982ecbb6a6e90869b15c1673be90bd18c8a56ff1cffc0864e38e2edffaefa", size = 80198, upload-time = "2024-05-31T01:40:54.722Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/41/28dae1ec1fe0151373f06bd06d9170ca14b52d5b3a6c2dc55f85bc219619/opentelemetry_semantic_conventions-0.46b0-py3-none-any.whl", hash = "sha256:6daef4ef9fa51d51855d9f8e0ccd3a1bd59e0e545abe99ac6203804e36ab3e07", size = 130549, upload-time = "2024-05-31T01:40:35.348Z" },
-]
-
-[[package]]
-name = "opentelemetry-util-http"
-version = "0.46b0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/91/45bf243850463b2c83000ca129442255eaef7c446bd0f59a2ab54b15abff/opentelemetry_util_http-0.46b0.tar.gz", hash = "sha256:03b6e222642f9c7eae58d9132343e045b50aca9761fcb53709bd2b663571fdf6", size = 7387, upload-time = "2024-05-31T16:18:21.321Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/7f/26d3d8880ea79adde8bb7bc306b25ca5134d6f6c3006ba464716405b4729/opentelemetry_util_http-0.46b0-py3-none-any.whl", hash = "sha256:8dc1949ce63caef08db84ae977fdc1848fe6dc38e6bbaad0ae3e6ecd0d451629", size = 6920, upload-time = "2024-05-31T16:17:25.344Z" },
+    { url = "https://files.pythonhosted.org/packages/45/31/1d86efd8c633bfab1074e7592bc27e36cb387d2969357be3f991f2d3a995/nono_py-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:18e27fb731bdd97fbb6e308be683d5f1dc77ff368aec37b615a57bf7fe0615d0", size = 7877832, upload-time = "2026-07-20T19:41:03.559Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/f8/d3f74c0a0690c43c36bccfb0e5ece229197100858510d82dfac395f16158/nono_py-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09fdea3591b21ae2f160cecb3b27f4e07a7aed8ab9b21cca580d5128c65aedd8", size = 7613127, upload-time = "2026-07-20T19:41:05.36Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/42/7a0bd9190f032766482c451271e714f6eb5b1d1fa27e1081686cf867a8e2/nono_py-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7ef6f181cd2501d64552ec1a8284daceafce8a62e6d4e0b60c2ae37ff1d05b3", size = 10051154, upload-time = "2026-07-20T19:41:07.257Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ea/2adeb23ad7a1d8c093f59c9f592101a2247d4be72033c5522297e76a1189/nono_py-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b6f6345211ffdc06fb9ef4e9be7d57cf4bc8f06003b2c388911b79ab4406dbd", size = 9870125, upload-time = "2026-07-20T19:41:09.315Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0d/1b4884e7b5842500865dfa7cf13872547c2eac9297989603fd052d1b1752/nono_py-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e3c3f198baa160b76a7774ec5fb4671779dfcb1e93719b8cd35d0cd62eaf4803", size = 7879839, upload-time = "2026-07-20T19:41:11.382Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f9/a7b87c5983eab8a5a057cdab15898e5b0c036b79bc47bdb1764dd456c02a/nono_py-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:65a64aa2f95b14439cea774b69216f2fe74fd3ae7649e80c086547ab119a03b6", size = 7618871, upload-time = "2026-07-20T19:41:12.973Z" },
+    { url = "https://files.pythonhosted.org/packages/de/23/e5cb4dff02cc95f949c4b5fc2773eccff883b619d5ba19ea8f43d7ba48b1/nono_py-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d73b7343638ea962ecdfd0ca49b666d42fcbc09fb840a6de587470ba94bb0760", size = 10058934, upload-time = "2026-07-20T19:41:14.849Z" },
+    { url = "https://files.pythonhosted.org/packages/57/85/a298531ccff31054b93776b0bce9ba150c199371c10cd886a7ace3d76a04/nono_py-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d12f303fdec6205c2137d3eed526589a6ff3834b970f46f5037ee01d46ebbd4", size = 9876716, upload-time = "2026-07-20T19:41:17.038Z" },
 ]
 
 [[package]]
@@ -642,15 +503,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "peewee"
-version = "3.19.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/b0/79462b42e89764998756e0557f2b58a15610a5b4512fbbcccae58fba7237/peewee-3.19.0.tar.gz", hash = "sha256:f88292a6f0d7b906cb26bca9c8599b8f4d8920ebd36124400d0cbaaaf915511f", size = 974035, upload-time = "2026-01-07T17:24:59.597Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/41/19c65578ef9a54b3083253c68a607f099642747168fe00f3a2bceb7c3a34/peewee-3.19.0-py3-none-any.whl", hash = "sha256:de220b94766e6008c466e00ce4ba5299b9a832117d9eb36d45d0062f3cfd7417", size = 411885, upload-time = "2026-01-07T17:24:58.33Z" },
 ]
 
 [[package]]
@@ -672,20 +524,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
-]
-
-[[package]]
-name = "protobuf"
-version = "4.25.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/01/34c8d2b6354906d728703cb9d546a0e534de479e25f1b581e4094c4a85cc/protobuf-4.25.8.tar.gz", hash = "sha256:6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd", size = 380920, upload-time = "2025-05-28T14:22:25.153Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/ff/05f34305fe6b85bbfbecbc559d423a5985605cad5eda4f47eae9e9c9c5c5/protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0", size = 392745, upload-time = "2025-05-28T14:22:10.524Z" },
-    { url = "https://files.pythonhosted.org/packages/08/35/8b8a8405c564caf4ba835b1fdf554da869954712b26d8f2a98c0e434469b/protobuf-4.25.8-cp310-abi3-win_amd64.whl", hash = "sha256:bd551eb1fe1d7e92c1af1d75bdfa572eff1ab0e5bf1736716814cdccdb2360f9", size = 413736, upload-time = "2025-05-28T14:22:13.156Z" },
-    { url = "https://files.pythonhosted.org/packages/28/d7/ab27049a035b258dab43445eb6ec84a26277b16105b277cbe0a7698bdc6c/protobuf-4.25.8-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:ca809b42f4444f144f2115c4c1a747b9a404d590f18f37e9402422033e464e0f", size = 394537, upload-time = "2025-05-28T14:22:14.768Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/6d/a4a198b61808dd3d1ee187082ccc21499bc949d639feb948961b48be9a7e/protobuf-4.25.8-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9ad7ef62d92baf5a8654fbb88dac7fa5594cfa70fd3440488a5ca3bfc6d795a7", size = 294005, upload-time = "2025-05-28T14:22:16.052Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c6/c9deaa6e789b6fc41b88ccbdfe7a42d2b82663248b715f55aa77fbc00724/protobuf-4.25.8-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:83e6e54e93d2b696a92cad6e6efc924f3850f82b52e1563778dfab8b355101b0", size = 294924, upload-time = "2025-05-28T14:22:17.105Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c1/6aece0ab5209981a70cd186f164c133fdba2f51e124ff92b73de7fd24d78/protobuf-4.25.8-py3-none-any.whl", hash = "sha256:15a0af558aa3b13efef102ae6e4f3efac06f1eea11afb3a57db2901447d9fb59", size = 156757, upload-time = "2025-05-28T14:22:24.135Z" },
 ]
 
 [[package]]
@@ -898,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -906,9 +744,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -991,15 +829,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ruamel-yaml"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1026,14 +855,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
 ]
 
 [[package]]
@@ -1046,58 +875,21 @@ wheels = [
 ]
 
 [[package]]
-name = "semgrep"
-version = "1.121.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "boltons" },
-    { name = "click" },
-    { name = "click-option-group" },
-    { name = "colorama" },
-    { name = "defusedxml" },
-    { name = "exceptiongroup" },
-    { name = "glom" },
-    { name = "jsonschema" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-    { name = "opentelemetry-instrumentation-requests" },
-    { name = "opentelemetry-sdk" },
-    { name = "packaging" },
-    { name = "peewee" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "ruamel-yaml" },
-    { name = "tomli" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "wcmatch" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/40/eca39d6580da0c17a48da0775cf8a2823ee13e8e809acb6c20911012004e/semgrep-1.121.0.tar.gz", hash = "sha256:3211f673024835e7dfdc32e1e83a5dc4ccf295daa489191f0b2fa02ac8e10723", size = 40096507, upload-time = "2025-05-07T02:36:36.903Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/1c/fca008abc4ffafeaa1818f0944bef9dbfb17ac2d8b11ff0df60f914e1d43/semgrep-1.121.0-cp39.cp310.cp311.py39.py310.py311-none-macosx_10_14_x86_64.whl", hash = "sha256:0ece86f06b049242c9ada1f5e5413abcc0a23c218b3e31f459635403d30d1b44", size = 34816989, upload-time = "2025-05-07T02:36:19.108Z" },
-    { url = "https://files.pythonhosted.org/packages/39/67/9dd0c193dac15d4e74c81b74536e0ebc2fc9bcfbe842e781c68a7d16e808/semgrep-1.121.0-cp39.cp310.cp311.py39.py310.py311-none-macosx_11_0_arm64.whl", hash = "sha256:e427dd2e2432263b7a243f14738e6879bfe08bb086932b37230e86cd67de0398", size = 39695859, upload-time = "2025-05-07T02:36:23.01Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/72/9743a83cd815b0b01c9e8ffd9dc7884fd45f7e15ab0894785a464275ac4a/semgrep-1.121.0-cp39.cp310.cp311.py39.py310.py311-none-musllinux_1_0_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ed5d1490c38f58f683fd10c5ee16515336424c7e70d158a7e6e3821b2b30485", size = 52153283, upload-time = "2025-05-07T02:36:26.222Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b8/81bc9b141c860b5a1eac58454ffd330a11c37cc99ab21b565547101bb082/semgrep-1.121.0-cp39.cp310.cp311.py39.py310.py311-none-musllinux_1_0_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09cad989bf1897b1c1bf94360fbc3aa53825b4c687d38678d43eeda66ad99eb9", size = 48406815, upload-time = "2025-05-07T02:36:30.063Z" },
-    { url = "https://files.pythonhosted.org/packages/06/df/94d12cf4bcfd293036e7b5dd19840400a30cbc1f3221e245049e92d5e36e/semgrep-1.121.0-cp39.cp310.cp311.py39.py310.py311-none-win_amd64.whl", hash = "sha256:dc697f87f98ae3538018cc57058054705385351655150360f89b3f1c0da2e5d9", size = 40662294, upload-time = "2025-05-07T02:36:33.707Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "82.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
 ]
 
 [[package]]
@@ -1111,20 +903,11 @@ wheels = [
 
 [[package]]
 name = "termcolor"
-version = "2.5.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/72/88311445fd44c455c7d553e61f95412cf89054308a1aa2434ab835075fc5/termcolor-2.5.0.tar.gz", hash = "sha256:998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f", size = 13057, upload-time = "2024-10-06T19:50:04.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/be/df630c387a0a054815d60be6a97eb4e8f17385d5d6fe660e1c02750062b4/termcolor-2.5.0-py3-none-any.whl", hash = "sha256:37b17b5fc1e604945c2642c872a3764b5d547a48009871aea3edd3afa180afb8", size = 7755, upload-time = "2024-10-06T19:50:02.097Z" },
-]
-
-[[package]]
-name = "tomli"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096, upload-time = "2024-10-02T10:46:13.208Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237, upload-time = "2024-10-02T10:46:11.806Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]
@@ -1153,11 +936,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]
@@ -1174,23 +957,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "wcmatch"
-version = "8.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bracex" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/c4/55e0d36da61d7b8b2a49fd273e6b296fd5e8471c72ebbe438635d1af3968/wcmatch-8.5.2.tar.gz", hash = "sha256:a70222b86dea82fb382dd87b73278c10756c138bd6f8f714e2183128887b9eb2", size = 114983, upload-time = "2024-05-15T12:51:08.054Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/78/533ef890536e5ba0fd4f7df37482b5800ecaaceae9afc30978a1a7f88ff1/wcmatch-8.5.2-py3-none-any.whl", hash = "sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478", size = 39397, upload-time = "2024-05-15T12:51:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -1200,45 +971,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "1.17.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
-    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
-    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
-    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
-    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
-    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
-    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]
@@ -1259,13 +991,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/28/9499649cb2cb42592c13ca6a15163e0cbf132c2974394de171aa5f8b49e4/yara_python-4.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb0f0e7183165426b09e2b1235e70909e540ac18e2c6be96070dfe17d7db4d78", size = 2639628, upload-time = "2025-05-27T14:15:22.142Z" },
     { url = "https://files.pythonhosted.org/packages/ac/37/e8f2b9a2287070f39fa6a5afbcf1ed6762f60ab3b1fb08018732838ccc25/yara_python-4.5.4-cp313-cp313-win32.whl", hash = "sha256:7707b144c8fcdb30c069ea57b94799cd7601f694ba01b696bbd1832721f37fd0", size = 1447395, upload-time = "2025-05-27T14:15:25.237Z" },
     { url = "https://files.pythonhosted.org/packages/cc/a0/40b0291c8b24d13daf0e26538c9f3a0d843c38c6446dd17f36335bdd5b5f/yara_python-4.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:5f1288448991d63c1f6351c9f6d112916b0177ceefaa27d1419427a6ff09f829", size = 1825779, upload-time = "2025-05-27T14:15:26.802Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]

--- a/apps/scanner/uv.lock
+++ b/apps/scanner/uv.lock
@@ -445,6 +445,7 @@ job = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "boto3" },
     { name = "guarddog" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -469,6 +470,7 @@ provides-extras = ["dev", "job"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = "==1.9.4" },
+    { name = "boto3" },
     { name = "guarddog", specifier = "==3.1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },


### PR DESCRIPTION
Closes nothing on its own — this makes #130's scanner usable on the existing fleet.

## What was wrong

#130 fixed the ownership bugs that had stopped GuardDog running at all, and pinned it to 3.1.0. Once it could run, CQ-02 read 3.x's rule output through 2.x assumptions and failed the first bundle it saw:

```
compliance: level 0     risk_score: CRITICAL     CQ-02: fail     degraded: false
```

`degraded: false` — the scanner considered that a real measurement. Every finding was CRITICAL, including ones inside `@modelcontextprotocol/sdk`.

## What changed

**`capability-*` rules are not verdicts.** GuardDog 3.x names rules by intent: `capability-*` states what code is *able* to do — open a socket, read a file, spawn a process — and `threat-*` is the accusation. An MCP server trips several capability rules by existing; the ones flagged here were an API client making network calls and a config module reading its key. Anything not `capability-*` is still treated as a verdict, so a rule added later blocks until someone decides otherwise.

**Dependency paths are recognised.** GuardDog reports paths relative to the directory it scanned, so matching against `/node_modules/` never matched anything and bundles were charged for code they merely depend on. Now matched on path components.

**Reading the environment is reported rather than blocking**, since that is how an MCP server receives its credentials.

**Reading a `.env` is exempted by which file was read, not by rule.** `threat-filesystem-read` is GuardDog's credential-access rule: the same rule matches `/etc/shadow`, `.ssh/id_rsa`, `.aws/credentials`, `.npmrc` and the browser credential stores as well as `.env`. GuardDog reports which string matched, so the exemption is gated on that: a `.env` the bundle reaches relatively passes, and everything else fails — including `.envrc`, which is direnv's, and a `.env` named by an absolute or home-relative path, which belongs to someone else.

**Dev runs what production runs.** The dev environment resolved GuardDog 2.7.0 while the image ran 3.1.0, so nothing exercised the taxonomy this code reads. Worse, the 3.x-named exception set did not match 2.x's rule names, so local scans would have over-blocked where production under-blocked. GuardDog and bandit are now pinned to the image's versions.

**A missing e2e corpus can fail rather than skip.** The corpus is gitignored and a missing one skipped silently, so the only tests that run real tools against real bundles were invisible — green in CI while failing locally. That blind spot is what let the regression below reach review. `MPAK_E2E_REQUIRED` now turns a missing corpus into a failure.

Wiring CI to use it was attempted here and reverted: the runner has no syft, grype, trufflehog or eslint, so the controls error rather than analyse. What that actually needs is recorded in #137 with the CI output showing it.

## A regression this went through

An earlier revision decided severity by rule alone, ignoring location entirely, to close a bypass. Measured against the repo's own corpus, that was worse than the bug being fixed:

| bundle | before | with that change |
|---|---|---|
| finnhub | level 1 | level 0 — 15 CRITICAL in `typer`, `pyperclip` |
| folk | level 1 | level 0 — 15 CRITICAL in `pyperclip` |

GuardDog's threat rules fire readily on ordinary libraries, and `deps/` is where Python MCPB bundles vendor everything. Reverted: vendored findings are reported, not blocking.

That leaves the bypass open — the path is author-controlled, so a payload in a directory named `vendor` exempts itself. It is real, and the wrong trade to close this way, since it costs a measured fleet regression to avoid a hypothetical one. Closing it properly means attributing against the SBOM SC-01 already produces, which knows whether `deps/yaml` is actually PyYAML. Tracked in #136, along with the same defect pointed the other way in CQ-01.

## Verification

Measured, not reasoned. All four bundles, real analyser:

| bundle | CQ-02 | findings |
|---|---|---|
| finnhub | pass | 27 info |
| folk | pass | 26 info |
| nationalparks | pass | 15 info, 1 medium |
| ipgeolocation | pass | 8 info, 1 medium |

`nationalparks` previously failed CQ-02 on `dotenv.config()` in its own code.

179 tests pass locally with `MPAK_E2E_REQUIRED=1`: 161 unit (23 new), 18 e2e. CI runs the 161. Three of the new tests drive the real analyser rather than mocked output, and two of them fail against the previous classifier — a mocked suite cannot see a taxonomy change.

## Note on the MTF spec

A comment claimed CQ-02 evaluates server code only, per the spec. It does not: MTF-0.1 §CQ-02 reads "Bundle MUST NOT contain detected malware patterns", with no carve-out. The dependency exemption is a concession to detector precision, and the code now says that instead.
