### PR TITLE
release: scanner@0.2.8

### DIFF
--- a/apps/scanner/Dockerfile
+++ b/apps/scanner/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.13-slim
-ARG SCANNER_VERSION=0.2.7
+ARG SCANNER_VERSION=0.2.8
 
 # Analysis tools are pinned. This image is rebuilt on a schedule to refresh the
 # baked vulnerability database, so anything unpinned would silently re-resolve

--- a/apps/scanner/pyproject.toml
+++ b/apps/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mpak-scanner"
-version = "0.2.7"
+version = "0.2.8"
 description = "Security scanner for MCP bundles. Powers mpak Certified verification."
 readme = "README.md"
 license = "Apache-2.0"

--- a/apps/scanner/uv.lock
+++ b/apps/scanner/uv.lock
@@ -422,7 +422,7 @@ wheels = [
 
 [[package]]
 name = "mpak-scanner"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump so #135 reaches a published artifact.

The image installs `mpak-scanner==${SCANNER_VERSION}` from PyPI, and 0.2.7 is already released — so the CQ-02 taxonomy fix is on `main` but in nothing deployable. Tagging `scanner-v0.2.8` after this merges publishes it and rebuilds the image.

Bumps `pyproject.toml` and the Dockerfile's default `ARG` together, and relocks.