### PR TITLE
fix(scanner): drive the static-analysis tools correctly, and never on trust

### DIFF
--- a/apps/scanner/CLAUDE.md
+++ b/apps/scanner/CLAUDE.md
@@ -108,9 +108,7 @@ class SC99NewControl(Control):
 ## External Tools
 
 Controls use these external tools. A missing tool is an ERROR, not a skip —
-a control that never ran cannot vouch for the bundle. CQ-03 is the exception
-for now: its tool handling is being reworked separately, and it still treats a
-missing tool as an informational pass.
+a control that never ran cannot vouch for the bundle:
 
 | Tool | Control | Language | Install |
 |------|---------|----------|---------|
@@ -130,7 +128,10 @@ Tools are invoked **by absolute path, never through `npx`, and never with the
 bundle as the working directory**. `npx` prefers `./node_modules/.bin`, so a
 bundle shipping its own `eslint` would have that binary executed by the scan
 pod — which holds S3 credentials and the callback secret. Running inside the
-bundle would also let it supply its own tool configuration.
+bundle would also let it supply its own tool configuration. ESLint additionally
+runs with `--no-config-lookup` and a working directory anchored at the
+filesystem root: with that flag the working directory is its config base path,
+and any file outside it is silently skipped.
 
 When a tool runs but cannot produce a result — grype without a usable
 vulnerability database, a scanner that crashes — the control reports `ERROR`,

--- a/apps/scanner/CLAUDE.md
+++ b/apps/scanner/CLAUDE.md
@@ -117,7 +117,7 @@ a control that never ran cannot vouch for the bundle:
 | TruffleHog | CQ-01 | All | `brew install trufflehog` |
 | GuardDog | CQ-02 | Python | `uv pip install guarddog` |
 | Bandit | CQ-03 | Python | `uv pip install bandit` |
-| ESLint | CQ-03 | JavaScript | `npm install -g eslint eslint-plugin-security` |
+| ESLint | CQ-03 | JavaScript | `npm install -g eslint eslint-plugin-security` (then `export NODE_PATH=$(npm root -g)`) |
 
 Tool versions are **pinned in the Dockerfile**. The image is rebuilt nightly to
 refresh the baked vulnerability database, so an unpinned tool would silently
@@ -131,7 +131,9 @@ pod — which holds S3 credentials and the callback secret. Running inside the
 bundle would also let it supply its own tool configuration. ESLint additionally
 runs with `--no-config-lookup` and a working directory anchored at the
 filesystem root: with that flag the working directory is its config base path,
-and any file outside it is silently skipped.
+and any file outside it is silently skipped. That also means it resolves plugins
+through `NODE_PATH` rather than from the file's own tree, which the image sets
+and a local install needs to export.
 
 When a tool runs but cannot produce a result — grype without a usable
 vulnerability database, a scanner that crashes — the control reports `ERROR`,

--- a/apps/scanner/Dockerfile
+++ b/apps/scanner/Dockerfile
@@ -46,7 +46,11 @@ RUN grype db update && grype db status && chown -R 1000:1000 /opt/grype-db
 # TruffleHog (secret detection)
 RUN curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin "${TRUFFLEHOG_VERSION}"
 
-# ESLint with security plugin (JS/TS static analysis)
+# ESLint with security plugin (JS/TS static analysis).
+# NODE_PATH lets ESLint resolve the globally installed plugin while analysing
+# files outside any node_modules tree -- it runs with --no-config-lookup and
+# absolute paths, anchored at the filesystem root rather than in the bundle.
+ENV NODE_PATH=/usr/local/lib/node_modules
 RUN npm install -g "eslint@${ESLINT_VERSION}" "eslint-plugin-security@${ESLINT_PLUGIN_SECURITY_VERSION}" --no-fund --no-audit
 
 # mpak-scanner + Python security tools (bandit, guarddog)

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq03_static_analysis.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq03_static_analysis.py
@@ -1,8 +1,6 @@
 """CQ-03: Static Analysis Clean control."""
 
-import functools
 import json
-import os
 import shutil
 import subprocess
 import time
@@ -44,36 +42,6 @@ def _is_test_path(relative: Path) -> bool:
     )
 
 
-@functools.cache
-def _global_node_modules() -> str | None:
-    """Where npm installs global packages, asked of npm rather than assumed.
-
-    ESLint runs with --no-config-lookup and absolute paths, so it resolves
-    plugins from NODE_PATH rather than from the file's own tree. Baking that
-    into the image alone would mean the documented local install still could
-    not find the plugin, which is the dev/production split these controls keep
-    getting caught by.
-    """
-    npm = shutil.which("npm")
-    if npm is None:
-        return None
-    try:
-        result = subprocess.run([npm, "root", "-g"], capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    return result.stdout.strip() or None if result.returncode == 0 else None
-
-
-def _eslint_env() -> dict[str, str]:
-    """Process environment for ESLint, with NODE_PATH resolved if unset."""
-    env = dict(os.environ)
-    if not env.get("NODE_PATH"):
-        global_modules = _global_node_modules()
-        if global_modules:
-            env["NODE_PATH"] = global_modules
-    return env
-
-
 def _is_dependency_path(relative: Path) -> bool:
     """Whether a bundle-relative path points into vendored dependency code."""
     return any(part in DEP_DIRS for part in relative.parts)
@@ -83,11 +51,15 @@ def _is_dependency_path(relative: Path) -> bool:
 # ESLint runs without a TypeScript parser, so it cannot lint TS sources -- it
 # reports them as ignored rather than analysing them. Bundles ship compiled
 # JavaScript, which is what actually executes and what these rules can read;
-# submitting .ts would only manufacture ignore notices, and .d.ts declaration
-# files carry no executable code at all. `.jsx` is out for the same reason: it
-# is absent from flat config's default glob (**/*.js, **/*.mjs, **/*.cjs), so
-# ESLint reports it ignored rather than analysing it.
-JS_EXTENSIONS = {".js", ".mjs", ".cjs"}
+# `.jsx` is absent from flat config's default glob (**/*.js, **/*.mjs,
+# **/*.cjs), so it needs --ext below to be linted rather than reported ignored.
+JS_EXTENSIONS = {".js", ".mjs", ".cjs", ".jsx"}
+
+# TypeScript needs a parser ESLint is not installed with, so these are found but
+# not analysed. Reported rather than dropped: executable code no tool inspected
+# is the thing this control exists to refuse to certify, and dropping them
+# silently made a .ts bundle pass on an analysis that never looked at it.
+UNANALYSED_SOURCE_EXTENSIONS = {".ts", ".tsx", ".mts", ".cts"}
 
 # Bandit severity/confidence mapping
 BANDIT_SEVERITY_MAP = {
@@ -134,6 +106,26 @@ class CQ03StaticAnalysis(Control):
         # Track if any analysis was run
         analysis_run = False
 
+        # Source the installed analysers cannot read is recorded before anything
+        # else, so a bundle carrying it cannot come back clean without the gap
+        # appearing alongside whatever else was found.
+        unanalysed = self._find_unanalysed_sources(bundle_dir)
+        if unanalysed:
+            listed = ", ".join(sorted(str(f.relative_to(bundle_dir)) for f in unanalysed)[:5])
+            findings.append(
+                Finding(
+                    id="CQ-03-COV-0000",
+                    control=self.id,
+                    severity=Severity.MEDIUM,
+                    title=f"Source not covered by any analyser ({len(unanalysed)} file(s))",
+                    description=(
+                        "TypeScript sources were found but no installed analyser can read "
+                        f"them, so they were not inspected: {listed}" + (" ..." if len(unanalysed) > 5 else "")
+                    ),
+                    remediation="Ship compiled JavaScript, which this control analyses",
+                )
+            )
+
         try:
             if python_files:
                 findings.extend(self._run_bandit(bundle_dir, python_files))
@@ -146,14 +138,18 @@ class CQ03StaticAnalysis(Control):
             return self.error(str(e), duration_ms=int((time.time() - start) * 1000))
 
         if not analysis_run:
-            # Nothing this control can read is not the same as nothing to find.
-            # A bundle shipping only TypeScript sources reaches here, and passing
-            # it would certify code no tool inspected. SKIP says the control did
-            # not apply, which caps the level honestly rather than vouching for
-            # the bundle -- the same choice CQ-02 makes for bundles with no
-            # ecosystem it can analyse.
-            return self.skip(
-                "No analysable Python or JavaScript found (excluding dependencies)",
+            # Nothing this control can read is not the same as nothing to find,
+            # so passing here would vouch for code no tool inspected. SKIP caps
+            # the level instead. Note this is a coverage gap, not a statement
+            # that the control does not apply: a bundle of TypeScript has plenty
+            # to analyse and no analyser installed to do it.
+            return ControlResult(
+                control_id=self.id,
+                control_name=self.name,
+                status=ControlStatus.SKIP,
+                findings=findings,
+                error="No analysable Python or JavaScript found (excluding dependencies)",
+                duration_ms=int((time.time() - start) * 1000),
             )
 
         duration = int((time.time() - start) * 1000)
@@ -181,6 +177,19 @@ class CQ03StaticAnalysis(Control):
             python_files.append(py_file)
 
         return python_files
+
+    def _find_unanalysed_sources(self, bundle_dir: Path) -> list[Path]:
+        """Server source files no installed analyser can read."""
+        found: list[Path] = []
+        for ext in UNANALYSED_SOURCE_EXTENSIONS:
+            for src in bundle_dir.rglob(f"*{ext}"):
+                relative = src.relative_to(bundle_dir)
+                if _is_dependency_path(relative) or _is_test_path(relative):
+                    continue
+                if relative.name.endswith(".d.ts"):
+                    continue  # declarations carry no executable code
+                found.append(src)
+        return found
 
     def _find_server_js_files(self, bundle_dir: Path) -> list[Path]:
         """Find JavaScript/TypeScript files that are server code (not dependencies)."""
@@ -332,6 +341,10 @@ class CQ03StaticAnalysis(Control):
                 [
                     eslint,
                     "--no-config-lookup",
+                    # Without this, flat config matches only .js/.mjs/.cjs and
+                    # reports .jsx ignored -- analysing nothing, silently.
+                    "--ext",
+                    ".jsx",
                     # Emitted with no ruleId against files ESLint analysed
                     # perfectly well, and unrelated to security. Off, so a
                     # rule-less message reliably means the file was skipped.
@@ -358,7 +371,6 @@ class CQ03StaticAnalysis(Control):
                 capture_output=True,
                 text=True,
                 timeout=120,
-                env=_eslint_env(),
                 # With --no-config-lookup, ESLint treats the working directory as
                 # the flat-config base path and silently ignores any file outside
                 # it. Anchor at the filesystem root so every absolute path is in

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq03_static_analysis.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq03_static_analysis.py
@@ -1,6 +1,8 @@
 """CQ-03: Static Analysis Clean control."""
 
+import functools
 import json
+import os
 import shutil
 import subprocess
 import time
@@ -10,11 +12,82 @@ from typing import Any
 from mpak_scanner.controls.base import Control, ControlRegistry
 from mpak_scanner.models import ControlResult, ControlStatus, Finding, Severity
 
+
+class ToolFailureError(Exception):
+    """A static-analysis tool could not produce a result.
+
+    Raised instead of returning no findings, so the control reports ERROR
+    rather than certifying the bundle on an analysis that never ran.
+    """
+
+
 # Directories that contain dependencies (not server code)
 DEP_DIRS = ["deps", "node_modules", "vendor", "site-packages", ".venv", "venv"]
 
+# Filenames that mark a file as tests rather than server code. Matched on path
+# components and stems, never as substrings: "test" appears inside `latest.js`,
+# "spec" inside `inspector.js`, and "deps" inside `depsolver.js`, so a substring
+# check silently drops ordinary server files -- and hands anyone who wants their
+# code unscanned a rename away from it.
+TEST_DIR_NAMES = {"test", "tests", "spec", "specs", "__tests__"}
+
+
+def _is_test_path(relative: Path) -> bool:
+    """Whether a bundle-relative path is a test file rather than server code."""
+    if any(part.lower() in TEST_DIR_NAMES for part in relative.parts[:-1]):
+        return True
+    stem = relative.stem.lower()
+    return (
+        stem.startswith(("test_", "spec_"))
+        or stem.endswith(("_test", "_spec", ".test", ".spec"))
+        or stem in TEST_DIR_NAMES
+    )
+
+
+@functools.cache
+def _global_node_modules() -> str | None:
+    """Where npm installs global packages, asked of npm rather than assumed.
+
+    ESLint runs with --no-config-lookup and absolute paths, so it resolves
+    plugins from NODE_PATH rather than from the file's own tree. Baking that
+    into the image alone would mean the documented local install still could
+    not find the plugin, which is the dev/production split these controls keep
+    getting caught by.
+    """
+    npm = shutil.which("npm")
+    if npm is None:
+        return None
+    try:
+        result = subprocess.run([npm, "root", "-g"], capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() or None if result.returncode == 0 else None
+
+
+def _eslint_env() -> dict[str, str]:
+    """Process environment for ESLint, with NODE_PATH resolved if unset."""
+    env = dict(os.environ)
+    if not env.get("NODE_PATH"):
+        global_modules = _global_node_modules()
+        if global_modules:
+            env["NODE_PATH"] = global_modules
+    return env
+
+
+def _is_dependency_path(relative: Path) -> bool:
+    """Whether a bundle-relative path points into vendored dependency code."""
+    return any(part in DEP_DIRS for part in relative.parts)
+
+
 # JavaScript/TypeScript file extensions
-JS_EXTENSIONS = {".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".mts", ".cts"}
+# ESLint runs without a TypeScript parser, so it cannot lint TS sources -- it
+# reports them as ignored rather than analysing them. Bundles ship compiled
+# JavaScript, which is what actually executes and what these rules can read;
+# submitting .ts would only manufacture ignore notices, and .d.ts declaration
+# files carry no executable code at all. `.jsx` is out for the same reason: it
+# is absent from flat config's default glob (**/*.js, **/*.mjs, **/*.cjs), so
+# ESLint reports it ignored rather than analysing it.
+JS_EXTENSIONS = {".js", ".mjs", ".cjs"}
 
 # Bandit severity/confidence mapping
 BANDIT_SEVERITY_MAP = {
@@ -61,32 +134,26 @@ class CQ03StaticAnalysis(Control):
         # Track if any analysis was run
         analysis_run = False
 
-        if python_files:
-            bandit_findings = self._run_bandit(bundle_dir, python_files)
-            findings.extend(bandit_findings)
-            analysis_run = True
+        try:
+            if python_files:
+                findings.extend(self._run_bandit(bundle_dir, python_files))
+                analysis_run = True
 
-        if js_files:
-            eslint_findings = self._run_eslint(bundle_dir, js_files)
-            findings.extend(eslint_findings)
-            analysis_run = True
+            if js_files:
+                findings.extend(self._run_eslint(bundle_dir, js_files))
+                analysis_run = True
+        except ToolFailureError as e:
+            return self.error(str(e), duration_ms=int((time.time() - start) * 1000))
 
         if not analysis_run:
-            # No server code files to analyze
-            return ControlResult(
-                control_id=self.id,
-                control_name=self.name,
-                status=ControlStatus.PASS,
-                findings=[
-                    Finding(
-                        id="CQ-03-0000",
-                        control=self.id,
-                        severity=Severity.INFO,
-                        title="No server code found",
-                        description="No Python or JavaScript files to analyze (excluding dependencies)",
-                    )
-                ],
-                duration_ms=int((time.time() - start) * 1000),
+            # Nothing this control can read is not the same as nothing to find.
+            # A bundle shipping only TypeScript sources reaches here, and passing
+            # it would certify code no tool inspected. SKIP says the control did
+            # not apply, which caps the level honestly rather than vouching for
+            # the bundle -- the same choice CQ-02 makes for bundles with no
+            # ecosystem it can analyse.
+            return self.skip(
+                "No analysable Python or JavaScript found (excluding dependencies)",
             )
 
         duration = int((time.time() - start) * 1000)
@@ -108,15 +175,7 @@ class CQ03StaticAnalysis(Control):
 
         for py_file in bundle_dir.rglob("*.py"):
             relative = py_file.relative_to(bundle_dir)
-            path_str = str(relative)
-
-            # Skip dependency directories
-            is_dep = any(dep_dir in path_str for dep_dir in DEP_DIRS)
-            if is_dep:
-                continue
-
-            # Skip test files
-            if "test" in path_str.lower() or "spec" in path_str.lower():
+            if _is_dependency_path(relative) or _is_test_path(relative):
                 continue
 
             python_files.append(py_file)
@@ -130,20 +189,26 @@ class CQ03StaticAnalysis(Control):
         for ext in JS_EXTENSIONS:
             for js_file in bundle_dir.rglob(f"*{ext}"):
                 relative = js_file.relative_to(bundle_dir)
-                path_str = str(relative)
-
-                # Skip dependency directories
-                is_dep = any(dep_dir in path_str for dep_dir in DEP_DIRS)
-                if is_dep:
-                    continue
-
-                # Skip test files
-                if "test" in path_str.lower() or "spec" in path_str.lower():
+                if _is_dependency_path(relative) or _is_test_path(relative):
                     continue
 
                 js_files.append(js_file)
 
         return js_files
+
+    @staticmethod
+    def _relative_to_bundle(path: str | None, bundle_dir: Path) -> str | None:
+        """Express a tool-reported path relative to the bundle.
+
+        Findings are published, and an absolute path inside the scan job means
+        nothing to a publisher looking at their own tree.
+        """
+        if not path:
+            return path
+        try:
+            return str(Path(path).relative_to(bundle_dir))
+        except ValueError:
+            return path
 
     def _run_bandit(self, bundle_dir: Path, python_files: list[Path]) -> list[Finding]:
         """Run Bandit static analysis on Python files."""
@@ -152,40 +217,59 @@ class CQ03StaticAnalysis(Control):
         # Create a file list for Bandit
         file_list = [str(f) for f in python_files]
 
+        bandit = shutil.which("bandit")
+        if bandit is None:
+            raise ToolFailureError("bandit not found; Python static analysis did not run")
+
         try:
+            # Absolute paths are passed, so no cwd is needed. Running inside the
+            # bundle would let it influence tool resolution and configuration.
             result = subprocess.run(
-                ["bandit", "-f", "json", "-r", "--exit-zero"] + file_list,
+                [bandit, "-f", "json", "-r", "--exit-zero"] + file_list,
                 capture_output=True,
                 text=True,
                 timeout=120,
             )
-        except FileNotFoundError:
-            findings.append(
-                Finding(
-                    id="CQ-03-0001",
-                    control=self.id,
-                    severity=Severity.INFO,
-                    title="Bandit not available",
-                    description="Install bandit for Python static analysis: pip install bandit",
-                )
-            )
-            return findings
-        except subprocess.TimeoutExpired:
-            findings.append(
-                Finding(
-                    id="CQ-03-0001",
-                    control=self.id,
-                    severity=Severity.MEDIUM,
-                    title="Static analysis timed out",
-                    description="Bandit analysis exceeded timeout",
-                )
-            )
-            return findings
+        except FileNotFoundError as e:
+            raise ToolFailureError("bandit not found; Python static analysis did not run") from e
+        except subprocess.TimeoutExpired as e:
+            # A timeout means the analysis did not finish, so its findings are
+            # unknown rather than absent -- the same reasoning as every other
+            # tool failure here.
+            raise ToolFailureError("bandit analysis timed out") from e
+
+        # Bandit runs with --exit-zero, so findings never set the exit code.
+        # Any non-zero status is therefore an internal failure.
+        if result.returncode != 0:
+            raise ToolFailureError(result.stderr.strip() or "bandit exited with an error")
+        if not result.stdout.strip():
+            raise ToolFailureError("bandit produced no output")
 
         try:
             if result.stdout.strip():
                 data = json.loads(result.stdout)
                 results = data.get("results", [])
+
+                # Bandit lists files it could not read or parse in `errors`,
+                # separately from `results`, while still exiting zero. Dropping
+                # them lets a file that was never analysed pass as clean. Like
+                # ESLint's fatal parse errors these describe the bundle, so they
+                # are findings rather than a tool failure.
+                for i, err in enumerate(data.get("errors") or []):
+                    findings.append(
+                        Finding(
+                            id=f"CQ-03-ERR-{i:04d}",
+                            control=self.id,
+                            severity=Severity.HIGH,
+                            title=f"File could not be analysed: {err.get('reason', 'unknown error')}",
+                            description=(
+                                "Bandit could not analyse this file, so it carries no "
+                                "static-analysis coverage and its contents are unverified."
+                            ),
+                            file=self._relative_to_bundle(err.get("filename"), bundle_dir),
+                            remediation="Ensure the file is valid, readable Python for the declared runtime",
+                        )
+                    )
 
                 for i, issue in enumerate(results):
                     severity_str = issue.get("issue_severity", "LOW")
@@ -195,14 +279,10 @@ class CQ03StaticAnalysis(Control):
                     mbss_severity = BANDIT_SEVERITY_MAP.get((severity_str, confidence_str), Severity.INFO)
 
                     file_path = issue.get("filename", "unknown")
-                    # Make path relative to bundle
-                    try:
-                        rel_path = str(Path(file_path).relative_to(bundle_dir))
-                    except ValueError:
-                        rel_path = file_path
+                    rel_path = self._relative_to_bundle(file_path, bundle_dir) or file_path
 
                     # Check if in deps
-                    in_deps = any(dep_dir in rel_path for dep_dir in DEP_DIRS)
+                    in_deps = _is_dependency_path(Path(rel_path))
 
                     findings.append(
                         Finding(
@@ -224,9 +304,8 @@ class CQ03StaticAnalysis(Control):
                         )
                     )
 
-        except json.JSONDecodeError:
-            # Bandit might output non-JSON on errors
-            pass
+        except json.JSONDecodeError as e:
+            raise ToolFailureError(f"Could not parse bandit output: {e}") from e
 
         return findings
 
@@ -246,22 +325,18 @@ class CQ03StaticAnalysis(Control):
         # and the callback secret, and could forge a clean result.
         eslint = shutil.which("eslint")
         if eslint is None:
-            findings.append(
-                Finding(
-                    id="CQ-03-JS-0001",
-                    control=self.id,
-                    severity=Severity.INFO,
-                    title="ESLint not available",
-                    description="Install ESLint for JavaScript static analysis: npm install -g eslint eslint-plugin-security",
-                )
-            )
-            return findings
+            raise ToolFailureError("eslint not found; JavaScript static analysis did not run")
 
         try:
             result = subprocess.run(
                 [
                     eslint,
-                    "--no-eslintrc",
+                    "--no-config-lookup",
+                    # Emitted with no ruleId against files ESLint analysed
+                    # perfectly well, and unrelated to security. Off, so a
+                    # rule-less message reliably means the file was skipped.
+                    "--report-unused-disable-directives-severity",
+                    "off",
                     "--plugin",
                     "eslint-plugin-security",
                     "--rule",
@@ -283,47 +358,64 @@ class CQ03StaticAnalysis(Control):
                 capture_output=True,
                 text=True,
                 timeout=120,
+                env=_eslint_env(),
+                # With --no-config-lookup, ESLint treats the working directory as
+                # the flat-config base path and silently ignores any file outside
+                # it. Anchor at the filesystem root so every absolute path is in
+                # scope. It must not be the bundle directory: that is what let a
+                # bundle supply its own tooling and configuration.
+                cwd=bundle_dir.anchor or "/",
             )
-        except FileNotFoundError:
-            findings.append(
-                Finding(
-                    id="CQ-03-JS-0001",
-                    control=self.id,
-                    severity=Severity.INFO,
-                    title="ESLint not available",
-                    description="Install ESLint for JavaScript static analysis: npm install -g eslint eslint-plugin-security",
-                )
-            )
-            return findings
-        except subprocess.TimeoutExpired:
-            findings.append(
-                Finding(
-                    id="CQ-03-JS-0001",
-                    control=self.id,
-                    severity=Severity.MEDIUM,
-                    title="ESLint analysis timed out",
-                    description="ESLint analysis exceeded timeout",
-                )
-            )
-            return findings
+        except FileNotFoundError as e:
+            raise ToolFailureError("eslint not found; JavaScript static analysis did not run") from e
+        except subprocess.TimeoutExpired as e:
+            raise ToolFailureError("eslint analysis timed out") from e
+
+        # ESLint exits 0 with no findings, 1 with findings, and 2 on an internal
+        # error -- a broken config, an unresolvable plugin, an unusable flag.
+        # Only 2 means nothing was analysed.
+        if result.returncode >= 2:
+            raise ToolFailureError(result.stderr.strip() or "eslint exited with an internal error")
+        if not result.stdout.strip():
+            raise ToolFailureError("eslint produced no output")
 
         try:
             if result.stdout.strip():
                 data = json.loads(result.stdout)
 
                 finding_counter = 0
+                files_analysed = 0
+                files_ignored: list[str] = []
                 for file_result in data:
                     file_path = file_result.get("filePath", "unknown")
-                    # Make path relative to bundle
-                    try:
-                        rel_path = str(Path(file_path).relative_to(bundle_dir))
-                    except ValueError:
-                        rel_path = file_path
+                    rel_path = self._relative_to_bundle(file_path, bundle_dir) or file_path
 
                     # Check if in deps
-                    in_deps = any(dep_dir in rel_path for dep_dir in DEP_DIRS)
+                    in_deps = _is_dependency_path(Path(rel_path))
 
-                    for msg in file_result.get("messages", []):
+                    messages = file_result.get("messages", [])
+
+                    # A rule-less, non-fatal message is ESLint talking about
+                    # itself rather than about the code -- most often that it
+                    # skipped the file. That is not a finding, and on its own it
+                    # is not a failure either: one skipped file among many says
+                    # nothing about the rest. Only a run in which no file was
+                    # analysed means the tool told us nothing about the bundle.
+                    #
+                    # `fatal` is excluded -- it marks a file ESLint could not
+                    # parse, which is a property of the bundle and stays a
+                    # finding.
+                    notices = [m for m in messages if m.get("ruleId") is None and not m.get("fatal")]
+                    if notices and len(notices) == len(messages):
+                        files_ignored.append(f"{rel_path}: {notices[0].get('message', 'skipped')}")
+                        continue
+
+                    files_analysed += 1
+
+                    for msg in messages:
+                        if msg.get("ruleId") is None and not msg.get("fatal"):
+                            continue
+
                         finding_counter += 1
                         severity_int = msg.get("severity", 1)
                         mtf_severity = ESLINT_SEVERITY_MAP.get(severity_int, Severity.LOW)
@@ -349,8 +441,13 @@ class CQ03StaticAnalysis(Control):
                             )
                         )
 
-        except json.JSONDecodeError:
-            # ESLint might output non-JSON on errors
-            pass
+                if files_analysed == 0:
+                    detail = "; ".join(files_ignored[:3])
+                    if len(files_ignored) > 3:
+                        detail += f" (+{len(files_ignored) - 3} more)"
+                    raise ToolFailureError(f"eslint analysed no files: {detail}")
+
+        except json.JSONDecodeError as e:
+            raise ToolFailureError(f"Could not parse eslint output: {e}") from e
 
         return findings

--- a/apps/scanner/src/mpak_scanner/controls/code_quality/cq03_static_analysis.py
+++ b/apps/scanner/src/mpak_scanner/controls/code_quality/cq03_static_analysis.py
@@ -186,7 +186,7 @@ class CQ03StaticAnalysis(Control):
                 relative = src.relative_to(bundle_dir)
                 if _is_dependency_path(relative) or _is_test_path(relative):
                     continue
-                if relative.name.endswith(".d.ts"):
+                if relative.name.endswith((".d.ts", ".d.mts", ".d.cts")):
                     continue  # declarations carry no executable code
                 found.append(src)
         return found
@@ -255,63 +255,62 @@ class CQ03StaticAnalysis(Control):
             raise ToolFailureError("bandit produced no output")
 
         try:
-            if result.stdout.strip():
-                data = json.loads(result.stdout)
-                results = data.get("results", [])
+            data = json.loads(result.stdout)
+            results = data.get("results", [])
 
-                # Bandit lists files it could not read or parse in `errors`,
-                # separately from `results`, while still exiting zero. Dropping
-                # them lets a file that was never analysed pass as clean. Like
-                # ESLint's fatal parse errors these describe the bundle, so they
-                # are findings rather than a tool failure.
-                for i, err in enumerate(data.get("errors") or []):
-                    findings.append(
-                        Finding(
-                            id=f"CQ-03-ERR-{i:04d}",
-                            control=self.id,
-                            severity=Severity.HIGH,
-                            title=f"File could not be analysed: {err.get('reason', 'unknown error')}",
-                            description=(
-                                "Bandit could not analyse this file, so it carries no "
-                                "static-analysis coverage and its contents are unverified."
-                            ),
-                            file=self._relative_to_bundle(err.get("filename"), bundle_dir),
-                            remediation="Ensure the file is valid, readable Python for the declared runtime",
-                        )
+            # Bandit lists files it could not read or parse in `errors`,
+            # separately from `results`, while still exiting zero. Dropping
+            # them lets a file that was never analysed pass as clean. Like
+            # ESLint's fatal parse errors these describe the bundle, so they
+            # are findings rather than a tool failure.
+            for i, err in enumerate(data.get("errors") or []):
+                findings.append(
+                    Finding(
+                        id=f"CQ-03-ERR-{i:04d}",
+                        control=self.id,
+                        severity=Severity.HIGH,
+                        title=f"File could not be analysed: {err.get('reason', 'unknown error')}",
+                        description=(
+                            "Bandit could not analyse this file, so it carries no "
+                            "static-analysis coverage and its contents are unverified."
+                        ),
+                        file=self._relative_to_bundle(err.get("filename"), bundle_dir),
+                        remediation="Ensure the file is valid, readable Python for the declared runtime",
                     )
+                )
 
-                for i, issue in enumerate(results):
-                    severity_str = issue.get("issue_severity", "LOW")
-                    confidence_str = issue.get("issue_confidence", "LOW")
+            for i, issue in enumerate(results):
+                severity_str = issue.get("issue_severity", "LOW")
+                confidence_str = issue.get("issue_confidence", "LOW")
 
-                    # Map Bandit severity/confidence to MTF severity
-                    mbss_severity = BANDIT_SEVERITY_MAP.get((severity_str, confidence_str), Severity.INFO)
+                # Map Bandit severity/confidence to MTF severity
+                mbss_severity = BANDIT_SEVERITY_MAP.get((severity_str, confidence_str), Severity.INFO)
 
-                    file_path = issue.get("filename", "unknown")
-                    rel_path = self._relative_to_bundle(file_path, bundle_dir) or file_path
+                file_path = issue.get("filename", "unknown")
+                rel_path = self._relative_to_bundle(file_path, bundle_dir) or file_path
 
-                    # Check if in deps
-                    in_deps = _is_dependency_path(Path(rel_path))
+                # Check if in deps
+                in_deps = _is_dependency_path(Path(rel_path))
 
-                    findings.append(
-                        Finding(
-                            id=f"CQ-03-{i + 1:04d}",
-                            control=self.id,
-                            severity=mbss_severity,
-                            title=f"{issue.get('test_id', 'B000')}: {issue.get('issue_text', 'Unknown issue')}",
-                            description=issue.get("issue_text", ""),
-                            file=rel_path,
-                            line=issue.get("line_number"),
-                            in_deps=in_deps,
-                            remediation=f"See: https://bandit.readthedocs.io/en/latest/plugins/{issue.get('test_id', '').lower()}.html",
-                            metadata={
-                                "test_id": issue.get("test_id"),
-                                "test_name": issue.get("test_name"),
-                                "severity": severity_str,
-                                "confidence": confidence_str,
-                            },
-                        )
+                findings.append(
+                    Finding(
+                        id=f"CQ-03-{i + 1:04d}",
+                        control=self.id,
+                        severity=mbss_severity,
+                        title=f"{issue.get('test_id', 'B000')}: {issue.get('issue_text', 'Unknown issue')}",
+                        description=issue.get("issue_text", ""),
+                        file=rel_path,
+                        line=issue.get("line_number"),
+                        in_deps=in_deps,
+                        remediation=f"See: https://bandit.readthedocs.io/en/latest/plugins/{issue.get('test_id', '').lower()}.html",
+                        metadata={
+                            "test_id": issue.get("test_id"),
+                            "test_name": issue.get("test_name"),
+                            "severity": severity_str,
+                            "confidence": confidence_str,
+                        },
                     )
+                )
 
         except json.JSONDecodeError as e:
             raise ToolFailureError(f"Could not parse bandit output: {e}") from e
@@ -342,9 +341,14 @@ class CQ03StaticAnalysis(Control):
                     eslint,
                     "--no-config-lookup",
                     # Without this, flat config matches only .js/.mjs/.cjs and
-                    # reports .jsx ignored -- analysing nothing, silently.
+                    # reports .jsx ignored -- analysing nothing, silently. The
+                    # parser option is required with it: espree cannot parse JSX
+                    # syntax by default, so --ext alone turns every real .jsx
+                    # into a fatal parse error, which this control reports as a
+                    # finding against the bundle.
                     "--ext",
                     ".jsx",
+                    "--parser-options=ecmaFeatures:{jsx:true}",
                     # Emitted with no ruleId against files ESLint analysed
                     # perfectly well, and unrelated to security. Off, so a
                     # rule-less message reliably means the file was skipped.
@@ -392,72 +396,71 @@ class CQ03StaticAnalysis(Control):
             raise ToolFailureError("eslint produced no output")
 
         try:
-            if result.stdout.strip():
-                data = json.loads(result.stdout)
+            data = json.loads(result.stdout)
 
-                finding_counter = 0
-                files_analysed = 0
-                files_ignored: list[str] = []
-                for file_result in data:
-                    file_path = file_result.get("filePath", "unknown")
-                    rel_path = self._relative_to_bundle(file_path, bundle_dir) or file_path
+            finding_counter = 0
+            files_analysed = 0
+            files_ignored: list[str] = []
+            for file_result in data:
+                file_path = file_result.get("filePath", "unknown")
+                rel_path = self._relative_to_bundle(file_path, bundle_dir) or file_path
 
-                    # Check if in deps
-                    in_deps = _is_dependency_path(Path(rel_path))
+                # Check if in deps
+                in_deps = _is_dependency_path(Path(rel_path))
 
-                    messages = file_result.get("messages", [])
+                messages = file_result.get("messages", [])
 
-                    # A rule-less, non-fatal message is ESLint talking about
-                    # itself rather than about the code -- most often that it
-                    # skipped the file. That is not a finding, and on its own it
-                    # is not a failure either: one skipped file among many says
-                    # nothing about the rest. Only a run in which no file was
-                    # analysed means the tool told us nothing about the bundle.
-                    #
-                    # `fatal` is excluded -- it marks a file ESLint could not
-                    # parse, which is a property of the bundle and stays a
-                    # finding.
-                    notices = [m for m in messages if m.get("ruleId") is None and not m.get("fatal")]
-                    if notices and len(notices) == len(messages):
-                        files_ignored.append(f"{rel_path}: {notices[0].get('message', 'skipped')}")
+                # A rule-less, non-fatal message is ESLint talking about
+                # itself rather than about the code -- most often that it
+                # skipped the file. That is not a finding, and on its own it
+                # is not a failure either: one skipped file among many says
+                # nothing about the rest. Only a run in which no file was
+                # analysed means the tool told us nothing about the bundle.
+                #
+                # `fatal` is excluded -- it marks a file ESLint could not
+                # parse, which is a property of the bundle and stays a
+                # finding.
+                notices = [m for m in messages if m.get("ruleId") is None and not m.get("fatal")]
+                if notices and len(notices) == len(messages):
+                    files_ignored.append(f"{rel_path}: {notices[0].get('message', 'skipped')}")
+                    continue
+
+                files_analysed += 1
+
+                for msg in messages:
+                    if msg.get("ruleId") is None and not msg.get("fatal"):
                         continue
 
-                    files_analysed += 1
+                    finding_counter += 1
+                    severity_int = msg.get("severity", 1)
+                    mtf_severity = ESLINT_SEVERITY_MAP.get(severity_int, Severity.LOW)
 
-                    for msg in messages:
-                        if msg.get("ruleId") is None and not msg.get("fatal"):
-                            continue
+                    rule_id = msg.get("ruleId") or "unknown"
+                    message = msg.get("message", "Unknown issue")
 
-                        finding_counter += 1
-                        severity_int = msg.get("severity", 1)
-                        mtf_severity = ESLINT_SEVERITY_MAP.get(severity_int, Severity.LOW)
-
-                        rule_id = msg.get("ruleId") or "unknown"
-                        message = msg.get("message", "Unknown issue")
-
-                        findings.append(
-                            Finding(
-                                id=f"CQ-03-JS-{finding_counter:04d}",
-                                control=self.id,
-                                severity=mtf_severity,
-                                title=f"{rule_id}: {message}",
-                                description=message,
-                                file=rel_path,
-                                line=msg.get("line"),
-                                in_deps=in_deps,
-                                remediation="See: https://github.com/eslint-community/eslint-plugin-security#rules",
-                                metadata={
-                                    "ruleId": rule_id,
-                                    "severity": severity_int,
-                                },
-                            )
+                    findings.append(
+                        Finding(
+                            id=f"CQ-03-JS-{finding_counter:04d}",
+                            control=self.id,
+                            severity=mtf_severity,
+                            title=f"{rule_id}: {message}",
+                            description=message,
+                            file=rel_path,
+                            line=msg.get("line"),
+                            in_deps=in_deps,
+                            remediation="See: https://github.com/eslint-community/eslint-plugin-security#rules",
+                            metadata={
+                                "ruleId": rule_id,
+                                "severity": severity_int,
+                            },
                         )
+                    )
 
-                if files_analysed == 0:
-                    detail = "; ".join(files_ignored[:3])
-                    if len(files_ignored) > 3:
-                        detail += f" (+{len(files_ignored) - 3} more)"
-                    raise ToolFailureError(f"eslint analysed no files: {detail}")
+            if files_analysed == 0:
+                detail = "; ".join(files_ignored[:3])
+                if len(files_ignored) > 3:
+                    detail += f" (+{len(files_ignored) - 3} more)"
+                raise ToolFailureError(f"eslint analysed no files: {detail}")
 
         except json.JSONDecodeError as e:
             raise ToolFailureError(f"Could not parse eslint output: {e}") from e

--- a/apps/scanner/tests/test_e2e_bundles.py
+++ b/apps/scanner/tests/test_e2e_bundles.py
@@ -14,6 +14,7 @@ Run:
 """
 
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -164,3 +165,65 @@ class TestFullScan:
 
         errors = [f"{cid}: {r.findings}" for cid, r in report.all_controls.items() if r.status == ControlStatus.ERROR]
         assert errors == [], f"Controls errored on {bundle.name}: {errors}"
+
+
+@pytest.mark.e2e
+class TestCQ03AgainstRealESLint:
+    """Drives the real ESLint binary, because the mocked suite cannot see argv.
+
+    Every other CQ-03 test monkeypatches subprocess.run and asserts on the
+    arguments, which is how `--no-eslintrc` survived against an ESLint 10 image
+    and how `--ext .jsx` without a parser option reached review: both suites
+    were green while the invocation was wrong. Only running the tool catches
+    that class.
+    """
+
+    @staticmethod
+    def _require_eslint() -> None:
+        if shutil.which("eslint") is None:
+            message = "eslint not installed (npm install -g eslint eslint-plugin-security)"
+            if os.environ.get("MPAK_E2E_REQUIRED"):
+                pytest.fail(message)
+            pytest.skip(message)
+
+    def test_real_jsx_component_does_not_false_fail(self, tmp_path: Path) -> None:
+        """JSX syntax must parse. Without the parser option it is a fatal error.
+
+        espree cannot read JSX by default, so `--ext .jsx` alone turns every
+        genuine component into `fatal: Parsing error`, which this control
+        reports as a HIGH finding and fails the bundle on.
+        """
+        self._require_eslint()
+        (tmp_path / "server.js").write_text("const a = 1;\n")
+        (tmp_path / "App.jsx").write_text("const App = () => <div>hi</div>;\nexport default App;\n")
+
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        result = CQ03StaticAnalysis().run(tmp_path, {})
+
+        assert result.status == ControlStatus.PASS, (
+            f"a benign JSX component failed CQ-03: {[(f.severity.value, f.title) for f in result.findings]}"
+        )
+
+    def test_real_jsx_payload_is_still_detected(self, tmp_path: Path) -> None:
+        """Parsing JSX must not come at the cost of analysing it."""
+        self._require_eslint()
+        (tmp_path / "Evil.jsx").write_text("const P = () => <b>{eval(process.env.P)}</b>;\nexport default P;\n")
+
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        result = CQ03StaticAnalysis().run(tmp_path, {})
+
+        assert result.status == ControlStatus.FAIL
+        assert any("detect-eval-with-expression" in f.title for f in result.findings)
+
+    def test_real_js_payload_is_detected(self, tmp_path: Path) -> None:
+        """The baseline the flag fix exists to preserve."""
+        self._require_eslint()
+        (tmp_path / "server.js").write_text("const x = eval(process.argv[2]);\n")
+
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        result = CQ03StaticAnalysis().run(tmp_path, {})
+
+        assert result.status == ControlStatus.FAIL

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -1946,23 +1946,28 @@ class TestCQ03JavaScript:
         assert result.status != ControlStatus.PASS
 
     def test_js_file_discovery(self, bundle_dir: Path) -> None:
-        """Discovers JavaScript, and deliberately not TypeScript or JSX.
+        """Discovers the JavaScript ESLint can lint, including .jsx.
 
-        ESLint runs without a TypeScript parser and its flat config does not
-        match .jsx, so submitting either only produces "file ignored" notices --
-        the appearance of coverage without any.
+        `.jsx` needs --ext to be matched by flat config, which the invocation
+        passes. TypeScript is discovered separately, as source no installed
+        analyser can read.
         """
         src = bundle_dir / "src"
         src.mkdir()
         (src / "server.js").write_text("console.log('hello');")
-        (src / "utils.ts").write_text("export const foo = 1;")
         (src / "widget.jsx").write_text("const a = 1;")
         (src / "index.mjs").write_text("export default {};")
+        (src / "utils.ts").write_text("export const foo = 1;")
 
         from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
 
-        js_files = CQ03StaticAnalysis()._find_server_js_files(bundle_dir)
-        assert {f.name for f in js_files} == {"server.js", "index.mjs"}
+        control = CQ03StaticAnalysis()
+        assert {f.name for f in control._find_server_js_files(bundle_dir)} == {
+            "server.js",
+            "widget.jsx",
+            "index.mjs",
+        }
+        assert {f.name for f in control._find_unanalysed_sources(bundle_dir)} == {"utils.ts"}
 
     def test_node_modules_excluded(self, bundle_dir: Path) -> None:
         """node_modules should be excluded from JS file discovery."""
@@ -2815,6 +2820,12 @@ class TestCQ02CredentialAccess:
         assert result.status == ControlStatus.FAIL
 
 
+# ESLint emits one entry per file it was given, so `[]` is not a clean run --
+# it is "no files analysed", which the control treats as a tool failure. Using
+# it as a success stub let tests assert on argv while the control errored.
+CLEAN_ESLINT_OUTPUT = json.dumps([{"filePath": "server.js", "messages": []}])
+
+
 class TestStaticAnalysisDoesNotCertifyUnrunTools:
     """CQ-03 is L2-required, so a tool that did not run must not read as clean."""
 
@@ -3011,7 +3022,7 @@ class TestStaticAnalysisDoesNotCertifyUnrunTools:
 
         def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
             seen.update(kwargs)
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=CLEAN_ESLINT_OUTPUT, stderr="")
 
         monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
         monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
@@ -3111,7 +3122,7 @@ class TestStaticAnalysisDoesNotCertifyUnrunTools:
 
         def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
             seen.extend(cmd)
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=CLEAN_ESLINT_OUTPUT, stderr="")
 
         monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
         monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
@@ -3195,19 +3206,29 @@ class TestCQ03Discovery:
         found = {f.name for f in CQ03StaticAnalysis()._find_server_js_files(d)}
         assert found == {"server.js"}
 
-    def test_jsx_is_not_submitted_to_eslint(self, tmp_path: Path) -> None:
-        """ESLint's flat config does not match .jsx, so submitting it is a no-op.
+    def test_jsx_is_submitted_to_eslint(self, tmp_path: Path) -> None:
+        """`.jsx` is lintable with --ext, so dropping it would just stop looking.
 
-        Left in, a .jsx-only bundle errors the control outright, and a mixed
-        bundle passes with the .jsx never inspected -- executable code certified
-        clean because the tool declined to look at it.
+        Left undiscovered, a bundle pairing a .jsx payload with any trivial .js
+        passed with the .jsx never inspected.
         """
         from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
 
         d = self._bundle(tmp_path, "src/server.js", "src/widget.jsx")
         found = {f.name for f in CQ03StaticAnalysis()._find_server_js_files(d)}
-        assert found == {"server.js"}
-        assert not any(f.suffix == ".jsx" for f in CQ03StaticAnalysis()._find_server_js_files(d))
+        assert found == {"server.js", "widget.jsx"}
+
+    def test_typescript_is_reported_as_uncovered_not_dropped(self, tmp_path: Path) -> None:
+        """Source no analyser can read must not vanish.
+
+        Dropping it silently let a bundle pairing a .ts payload with a trivial
+        .js come back clean on an analysis that never read the .ts.
+        """
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        d = self._bundle(tmp_path, "src/app.ts", "src/types.d.ts")
+        found = {f.name for f in CQ03StaticAnalysis()._find_unanalysed_sources(d)}
+        assert found == {"app.ts"}, "declaration files carry no executable code"
 
     def test_python_discovery_uses_the_same_rules(self, tmp_path: Path) -> None:
         """Both languages share the filtering, so both share the fix."""
@@ -3216,54 +3237,3 @@ class TestCQ03Discovery:
         d = self._bundle(tmp_path, "src/latest.py", "tests/conftest.py", "test_thing.py", "deps/lib/mod.py")
         found = {f.name for f in CQ03StaticAnalysis()._find_server_python_files(d)}
         assert found == {"latest.py"}
-
-    def test_eslint_resolves_plugins_without_a_preset_node_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The documented local install has to be enough on its own.
-
-        ESLint runs with --no-config-lookup and absolute paths, so it finds
-        plugins through NODE_PATH. Setting that only in the image would leave a
-        developer who followed the install instructions unable to run CQ-03.
-        """
-        (tmp_path / "server.js").write_text("var x = 1;\n")
-
-        from mpak_scanner.controls.code_quality import cq03_static_analysis
-
-        cq03_static_analysis._global_node_modules.cache_clear()
-        monkeypatch.delenv("NODE_PATH", raising=False)
-        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda n: f"/usr/bin/{n}")
-
-        seen: dict[str, object] = {}
-
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-            if cmd[1:3] == ["root", "-g"]:
-                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="/global/node_modules\n", stderr="")
-            seen.update(kwargs)
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="[]", stderr="")
-
-        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
-        cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
-
-        assert seen["env"]["NODE_PATH"] == "/global/node_modules"  # type: ignore[index]
-
-    def test_a_preset_node_path_is_left_alone(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The image sets it deliberately; do not second-guess that."""
-        (tmp_path / "server.js").write_text("var x = 1;\n")
-
-        from mpak_scanner.controls.code_quality import cq03_static_analysis
-
-        cq03_static_analysis._global_node_modules.cache_clear()
-        monkeypatch.setenv("NODE_PATH", "/image/node_modules")
-        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda n: f"/usr/bin/{n}")
-
-        seen: dict[str, object] = {}
-
-        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-            seen.update(kwargs)
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="[]", stderr="")
-
-        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
-        cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
-
-        assert seen["env"]["NODE_PATH"] == "/image/node_modules"  # type: ignore[index]

--- a/apps/scanner/tests/test_scanner.py
+++ b/apps/scanner/tests/test_scanner.py
@@ -1932,28 +1932,37 @@ class TestCQ03JavaScript:
         bundle.mkdir()
         return bundle
 
-    def test_no_js_files_passes(self, bundle_dir: Path) -> None:
-        """Bundle without JavaScript should pass CQ-03."""
+    def test_bundle_with_nothing_analysable_skips(self, bundle_dir: Path) -> None:
+        """No analysable code is not evidence of clean code.
+
+        Passing here would certify a bundle nothing inspected. SKIP caps the
+        level honestly instead, matching what CQ-02 does for bundles with no
+        ecosystem it can analyse.
+        """
         from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
 
-        control = CQ03StaticAnalysis()
-        result = control.run(bundle_dir, {})
-        assert result.status == ControlStatus.PASS
-        assert any("No server code found" in f.title for f in result.findings)
+        result = CQ03StaticAnalysis().run(bundle_dir, {})
+        assert result.status == ControlStatus.SKIP
+        assert result.status != ControlStatus.PASS
 
     def test_js_file_discovery(self, bundle_dir: Path) -> None:
-        """Should discover JavaScript and TypeScript files."""
+        """Discovers JavaScript, and deliberately not TypeScript or JSX.
+
+        ESLint runs without a TypeScript parser and its flat config does not
+        match .jsx, so submitting either only produces "file ignored" notices --
+        the appearance of coverage without any.
+        """
         src = bundle_dir / "src"
         src.mkdir()
         (src / "server.js").write_text("console.log('hello');")
         (src / "utils.ts").write_text("export const foo = 1;")
+        (src / "widget.jsx").write_text("const a = 1;")
         (src / "index.mjs").write_text("export default {};")
 
         from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
 
-        control = CQ03StaticAnalysis()
-        js_files = control._find_server_js_files(bundle_dir)
-        assert len(js_files) == 3
+        js_files = CQ03StaticAnalysis()._find_server_js_files(bundle_dir)
+        assert {f.name for f in js_files} == {"server.js", "index.mjs"}
 
     def test_node_modules_excluded(self, bundle_dir: Path) -> None:
         """node_modules should be excluded from JS file discovery."""
@@ -2804,3 +2813,457 @@ class TestCQ02CredentialAccess:
         """
         result = self._run(tmp_path, monkeypatch, match)
         assert result.status == ControlStatus.FAIL
+
+
+class TestStaticAnalysisDoesNotCertifyUnrunTools:
+    """CQ-03 is L2-required, so a tool that did not run must not read as clean."""
+
+    def test_bandit_internal_error_becomes_control_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bandit runs with --exit-zero, so a non-zero exit is an internal failure."""
+        (tmp_path / "server.py").write_text("import os\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=2, stdout="", stderr="bandit: boom")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/bandit")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+        assert result.status != ControlStatus.PASS
+
+    def test_eslint_internal_error_becomes_control_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ESLint exit 2 is an internal error -- a bad flag, an unresolvable plugin."""
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=2, stdout="", stderr="Invalid option '--eslintrc'")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+
+    def test_missing_tool_becomes_control_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An absent tool did not analyse anything; an INFO note and a pass hid that."""
+        (tmp_path / "server.py").write_text("import os\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: None)
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+
+    def test_eslint_findings_exit_code_still_reports_findings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exit 1 means ESLint found problems -- a real result, not a failure."""
+        (tmp_path / "server.js").write_text("var x = eval(u);\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        payload = json.dumps(
+            [
+                {
+                    "filePath": str(tmp_path / "server.js"),
+                    "messages": [
+                        {
+                            "ruleId": "security/detect-eval-with-expression",
+                            "message": "eval with expression",
+                            "severity": 2,
+                            "line": 1,
+                        }
+                    ],
+                }
+            ]
+        )
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status != ControlStatus.ERROR
+        assert any("detect-eval-with-expression" in f.title for f in result.findings)
+
+    def test_bandit_timeout_becomes_control_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An analysis that never finished has unknown findings, not none."""
+        (tmp_path / "server.py").write_text("import os\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd="bandit", timeout=120)
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/bandit")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+        assert result.status != ControlStatus.PASS
+
+    def test_eslint_timeout_becomes_control_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bundle that is slow to analyse must not certify as clean."""
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd="eslint", timeout=120)
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+
+    def test_eslint_ignored_file_notice_becomes_control_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ESLint ignoring every file must not read as a clean bundle.
+
+        With --no-config-lookup the working directory is the flat-config base
+        path, and a file outside it comes back as a rule-less warning with exit
+        0 and non-empty JSON -- so neither the exit-code nor the empty-output
+        guard sees it, and the parse loop would file it as a MEDIUM finding
+        while nothing was analysed.
+        """
+        (tmp_path / "server.js").write_text("var x = eval(u);\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        payload = json.dumps(
+            [
+                {
+                    "filePath": str(tmp_path / "server.js"),
+                    "messages": [
+                        {
+                            "ruleId": None,
+                            "severity": 1,
+                            "message": "File ignored because outside of base path.",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+        assert result.status != ControlStatus.PASS
+
+    def test_eslint_parse_error_stays_a_finding(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A file ESLint cannot parse is a property of the bundle, not a tool failure."""
+        (tmp_path / "bad.js").write_text("var x = ;;;broken(\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        payload = json.dumps(
+            [
+                {
+                    "filePath": str(tmp_path / "bad.js"),
+                    "messages": [
+                        {
+                            "ruleId": None,
+                            "fatal": True,
+                            "severity": 2,
+                            "message": "Parsing error: Unexpected token ;",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status != ControlStatus.ERROR
+        assert any("Parsing error" in f.title for f in result.findings)
+
+    def test_eslint_runs_from_a_root_anchored_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The working directory must contain the bundle, and must not be it.
+
+        Anything below the root risks ESLint ignoring files outside its base
+        path; the bundle itself would let it supply its own configuration.
+        """
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        seen: dict[str, object] = {}
+
+        def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            seen.update(kwargs)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+
+        cwd = str(seen["cwd"])
+        assert cwd == tmp_path.anchor
+        assert cwd != str(tmp_path)
+        assert str(tmp_path).startswith(cwd)
+
+    def test_eslint_skipped_file_alongside_analysed_files_is_not_an_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One skipped file says nothing about the rest of the bundle.
+
+        ESLint emits rule-less notices for files it declines to lint. Treating
+        any of them as a tool failure would stop every bundle carrying one from
+        ever certifying, which is the opposite of the intent.
+        """
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        payload = json.dumps(
+            [
+                {
+                    "filePath": str(tmp_path / "types.d.ts"),
+                    "messages": [
+                        {
+                            "ruleId": None,
+                            "fatal": False,
+                            "severity": 1,
+                            "message": "File ignored because no matching configuration was supplied.",
+                        }
+                    ],
+                },
+                {"filePath": str(tmp_path / "server.js"), "messages": []},
+            ]
+        )
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.PASS
+        # The notice is not a finding either -- it describes ESLint, not the code.
+        assert not any("File ignored" in f.title for f in result.findings)
+
+    def test_eslint_errors_only_when_no_file_was_analysed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every file skipped means the tool reported nothing about the bundle."""
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        payload = json.dumps(
+            [
+                {
+                    "filePath": str(tmp_path / f"{name}.js"),
+                    "messages": [
+                        {
+                            "ruleId": None,
+                            "fatal": False,
+                            "severity": 1,
+                            "message": "File ignored because outside of base path.",
+                        }
+                    ],
+                }
+                for name in ("a", "b")
+            ]
+        )
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert result.status == ControlStatus.ERROR
+
+    def test_eslint_disables_unused_directive_reporting(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unused eslint-disable comments are rule-less but not a skipped file.
+
+        Left on, they would be indistinguishable from a genuine skip notice.
+        """
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        seen: list[str] = []
+
+        def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            seen.extend(cmd)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/eslint")
+
+        cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert "--report-unused-disable-directives-severity" in seen
+        assert seen[seen.index("--report-unused-disable-directives-severity") + 1] == "off"
+
+    def test_bandit_unreadable_file_is_reported(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bandit lists unparseable files in `errors`, apart from `results`.
+
+        Reading only `results` let a file that was never analysed pass as clean.
+        """
+        (tmp_path / "server.py").write_text("import os\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        payload = json.dumps(
+            {
+                "results": [],
+                "errors": [
+                    {
+                        "filename": str(tmp_path / "bad.py"),
+                        "reason": "syntax error while parsing AST from file",
+                    }
+                ],
+            }
+        )
+
+        def fake_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=payload, stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda _n: "/usr/bin/bandit")
+
+        result = cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+        assert any("could not be analysed" in f.title for f in result.findings)
+        assert result.status != ControlStatus.PASS
+
+
+class TestCQ03Discovery:
+    """What reaches the analyser, and what silently does not.
+
+    Both failures here are invisible at runtime: a dropped file produces no
+    finding, which is indistinguishable from a clean one.
+    """
+
+    @staticmethod
+    def _bundle(tmp_path: Path, *names: str) -> Path:
+        for n in names:
+            f = tmp_path / n
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("var x = 1;\n" if f.suffix != ".py" else "import os\n")
+        return tmp_path
+
+    def test_ordinary_names_containing_test_or_spec_are_analysed(self, tmp_path: Path) -> None:
+        """Substring matching dropped real server files.
+
+        "test" appears inside `latest.js`, "spec" inside `inspector.js`, "deps"
+        inside `depsolver.js`. Dropping those is worse than noise: the file is
+        never analysed and nothing says so.
+        """
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        d = self._bundle(tmp_path, "dist/latest.js", "src/inspector.js", "lib/attestation.js", "src/depsolver.js")
+        found = {f.name for f in CQ03StaticAnalysis()._find_server_js_files(d)}
+        assert found == {"latest.js", "inspector.js", "attestation.js", "depsolver.js"}
+
+    def test_genuine_tests_and_dependencies_are_skipped(self, tmp_path: Path) -> None:
+        """The filtering still has to do its actual job."""
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        d = self._bundle(
+            tmp_path,
+            "src/server.js",
+            "tests/helper.js",
+            "src/thing.test.js",
+            "node_modules/dep/index.js",
+            "vendor/lib.js",
+        )
+        found = {f.name for f in CQ03StaticAnalysis()._find_server_js_files(d)}
+        assert found == {"server.js"}
+
+    def test_jsx_is_not_submitted_to_eslint(self, tmp_path: Path) -> None:
+        """ESLint's flat config does not match .jsx, so submitting it is a no-op.
+
+        Left in, a .jsx-only bundle errors the control outright, and a mixed
+        bundle passes with the .jsx never inspected -- executable code certified
+        clean because the tool declined to look at it.
+        """
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        d = self._bundle(tmp_path, "src/server.js", "src/widget.jsx")
+        found = {f.name for f in CQ03StaticAnalysis()._find_server_js_files(d)}
+        assert found == {"server.js"}
+        assert not any(f.suffix == ".jsx" for f in CQ03StaticAnalysis()._find_server_js_files(d))
+
+    def test_python_discovery_uses_the_same_rules(self, tmp_path: Path) -> None:
+        """Both languages share the filtering, so both share the fix."""
+        from mpak_scanner.controls.code_quality import CQ03StaticAnalysis
+
+        d = self._bundle(tmp_path, "src/latest.py", "tests/conftest.py", "test_thing.py", "deps/lib/mod.py")
+        found = {f.name for f in CQ03StaticAnalysis()._find_server_python_files(d)}
+        assert found == {"latest.py"}
+
+    def test_eslint_resolves_plugins_without_a_preset_node_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The documented local install has to be enough on its own.
+
+        ESLint runs with --no-config-lookup and absolute paths, so it finds
+        plugins through NODE_PATH. Setting that only in the image would leave a
+        developer who followed the install instructions unable to run CQ-03.
+        """
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        cq03_static_analysis._global_node_modules.cache_clear()
+        monkeypatch.delenv("NODE_PATH", raising=False)
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda n: f"/usr/bin/{n}")
+
+        seen: dict[str, object] = {}
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if cmd[1:3] == ["root", "-g"]:
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="/global/node_modules\n", stderr="")
+            seen.update(kwargs)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+
+        assert seen["env"]["NODE_PATH"] == "/global/node_modules"  # type: ignore[index]
+
+    def test_a_preset_node_path_is_left_alone(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The image sets it deliberately; do not second-guess that."""
+        (tmp_path / "server.js").write_text("var x = 1;\n")
+
+        from mpak_scanner.controls.code_quality import cq03_static_analysis
+
+        cq03_static_analysis._global_node_modules.cache_clear()
+        monkeypatch.setenv("NODE_PATH", "/image/node_modules")
+        monkeypatch.setattr(cq03_static_analysis.shutil, "which", lambda n: f"/usr/bin/{n}")
+
+        seen: dict[str, object] = {}
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            seen.update(kwargs)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(cq03_static_analysis.subprocess, "run", fake_run)
+        cq03_static_analysis.CQ03StaticAnalysis().run(tmp_path, {})
+
+        assert seen["env"]["NODE_PATH"] == "/image/node_modules"  # type: ignore[index]


### PR DESCRIPTION
Replaces #134, rebuilt on current `main`. #134 branched before the GuardDog taxonomy work, so merging it would have reverted the credential-access fix and rolled the scanner version below what is published.

## What was wrong

**JavaScript analysis had never run.** The image resolves eslint 10 while the invocation used the v8 flag `--no-eslintrc`. Every JS bundle exited 2 with empty output, and with no exit-code check that read as clean.

**A second way to analyse nothing.** With `--no-config-lookup`, ESLint's config base path *is* the working directory, and files outside it are silently skipped — exit 0, non-empty JSON, one rule-less notice per file.

**Bandit reports out-of-band.** It lists files it could not read in a top-level `errors` array while exiting zero, so an unreadable file contributed nothing and the control passed.

**Discovery dropped ordinary files.** The filters were unanchored substrings, so `dist/latest.js` ("test" in "latest"), `src/inspector.js` ("spec"), `src/depsolver.js` ("deps") never reached a tool. Pre-existing, but this change alters what it costs: those bundles reach the SKIP branch, and SKIP caps a level exactly as FAIL does while `degraded` stays false. It also offered a rename as a way to go unscanned.

## What changed

Corrected flags, a working directory anchored at the filesystem root, and discovery matched on path components and stems rather than substrings.

Every way a tool can fail to produce a result now errors instead of passing: non-zero exit, empty output, unparseable output, timeout. Bandit's `errors` entries become findings.

`.jsx` is linted, via `--ext .jsx` **and** `--parser-options=ecmaFeatures:{jsx:true}`. The flag alone is worse than dropping the extension: espree cannot parse JSX, so every real component becomes `fatal: Parsing error`, which this control reports as a HIGH finding and fails the bundle on.

**TypeScript is reported, not dropped.** No installed analyser can read it, so a bundle carrying `.ts` gets a MEDIUM finding naming the uninspected files. Dropping it silently let a `.ts` payload paired with any trivial `.js` come back clean. Installing a TypeScript parser is the real fix and is its own change.

## Verification

Against real ESLint 10.7.0 in the image, as uid 1000:

| case | result |
|---|---|
| `dist/latest.js` with a planted `eval` | discovered, analysed, **fail** |
| benign `.jsx` React component | **pass** — no parse error |
| `.jsx` containing `eval` | **fail** on `detect-eval-with-expression` |
| `.ts` payload + trivial `.js` | pass, with a medium coverage finding naming the `.ts` |
| planted `node_modules/.bin/eslint` | not executed |

Three of these run as e2e tests against the real binary rather than a mocked payload. Removing the parser option makes two of the three fail, which is the point: the mocked suite could not see `--no-eslintrc` on `main` and could not see a wrong `--ext` here.

175 tests in `test_scanner.py`, 200 collected across all files.

## Rollout note

CQ-03 now returns SKIP where it previously returned PASS for a bundle with no analysable Python or JavaScript. SKIP caps the level exactly as FAIL does, and `degraded` counts only ERROR, so such a bundle would publish a capped level as a completed scan.

Measured against the 32 published bundles that can be pulled: **0 would SKIP** — every one has analysable Python or JavaScript. Six carry TypeScript and would gain the medium coverage finding, which does not block. So the re-levelling has no effect on the current fleet, but it is a real shape and worth knowing before the next bundle class arrives.
