### PR TITLE
release: scanner@0.2.9

### DIFF
--- a/apps/scanner/Dockerfile
+++ b/apps/scanner/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.13-slim
-ARG SCANNER_VERSION=0.2.8
+ARG SCANNER_VERSION=0.2.9
 
 # Analysis tools are pinned. This image is rebuilt on a schedule to refresh the
 # baked vulnerability database, so anything unpinned would silently re-resolve

--- a/apps/scanner/pyproject.toml
+++ b/apps/scanner/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mpak-scanner"
-version = "0.2.8"
+version = "0.2.9"
 description = "Security scanner for MCP bundles. Powers mpak Certified verification."
 readme = "README.md"
 license = "Apache-2.0"

--- a/apps/scanner/uv.lock
+++ b/apps/scanner/uv.lock
@@ -422,7 +422,7 @@ wheels = [
 
 [[package]]
 name = "mpak-scanner"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Version bump so #140 reaches a published artifact.

The image installs `mpak-scanner==${SCANNER_VERSION}` from PyPI, and 0.2.8 is already released — so the CQ-03 fixes are on `main` but in nothing deployable. Tagging `scanner-v0.2.9` after this merges publishes them and rebuilds the image.

Bumps `pyproject.toml` and the Dockerfile's default `ARG` together, and relocks.