### PR TITLE
Release CLI 0.5.0 (bundle-only)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-23
+
+### Removed
+
+- **The `mpak skill` command namespace.** mpak now does one thing: package MCP
+  servers as portable, security-scanned MCPB bundles. `mpak skill search`,
+  `show`, `install`, `validate`, and `pack` are gone, and `mpak search` is now
+  bundle-only (`mpak bundle search --type` still filters by server type). Skill
+  packaging and distribution have moved to the `skills.sh` / `npx skills`
+  ecosystem. ([#126])
+
 ## [0.4.2] - 2026-05-06
 
 ### Changed
@@ -97,7 +108,8 @@ Initial public release.
 - Platform-aware bundle resolution (os/arch matching)
 - Python auto-detection (`python3` → `python` fallback) for Python-based bundles
 
-[Unreleased]: https://github.com/NimbleBrainInc/mpak/compare/cli-v0.4.2...HEAD
+[Unreleased]: https://github.com/NimbleBrainInc/mpak/compare/cli-v0.5.0...HEAD
+[0.5.0]: https://github.com/NimbleBrainInc/mpak/compare/cli-v0.4.2...cli-v0.5.0
 [0.4.2]: https://github.com/NimbleBrainInc/mpak/compare/cli-v0.4.1...cli-v0.4.2
 [0.4.1]: https://github.com/NimbleBrainInc/mpak/compare/cli-v0.4.0...cli-v0.4.1
 [0.4.0]: https://github.com/NimbleBrainInc/mpak/compare/cli-v0.3.4...cli-v0.4.0
@@ -115,3 +127,4 @@ Initial public release.
 [#77]: https://github.com/NimbleBrainInc/mpak/issues/77
 [#91]: https://github.com/NimbleBrainInc/mpak/issues/91
 [#94]: https://github.com/NimbleBrainInc/mpak/issues/94
+[#126]: https://github.com/NimbleBrainInc/mpak/pull/126

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblebrain/mpak",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "CLI for downloading MCPB bundles from the mpak registry",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Cut `@nimblebrain/mpak` 0.5.0

Ships the bundle-only CLI that landed in #126. Bumps `packages/cli/package.json` 0.4.2 → 0.5.0 (0.x breaking → minor) and records the change in the CLI CHANGELOG.

### Why now
The `/v1/skills` backend is already removed (#126), so `mpak skill *` on the published 0.4.2 already fails against the live registry. 0.5.0 removes the dead namespace so users get a clean `unknown command` instead of a 404.

### What changed
- `mpak skill` namespace removed; `mpak search` is bundle-only (`mpak bundle search --type` still filters by server type)
- No new code — the removal shipped in #126; this is the release bump + CHANGELOG

### Release mechanics
On merge, push tag `cli-v0.5.0` → `cli-publish.yml` verifies, enforces tag == package.json version, and publishes to npm with provenance.

Verified locally: build ✓, typecheck ✓, 104 tests ✓, `--version` → 0.5.0.