### PR TITLE
ci: bump node20 actions to their node24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,9 +40,11 @@ jobs:
         run: pnpm --filter mpak-docs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: apps/docs/dist
+          # v5 excludes hidden files by default; keep v3's include-everything behavior.
+          include-hidden-files: true
 
   deploy:
     needs: build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'apps/docs/**'
       - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -22,15 +22,15 @@ jobs:
         working-directory: apps/scanner
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
         with:
-          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
+          enable-cache: false  # no uv cache: v9 defaults to 'auto', and unpruned caching would eat the shared 10 GB Actions budget
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
+        with:
+          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - 'apps/scanner/**'
+      - '.github/workflows/scanner-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'apps/scanner/**'
+      - '.github/workflows/scanner-ci.yml'
 
 concurrency:
   group: scanner-ci-${{ github.ref }}

--- a/.github/workflows/scanner-image-refresh.yml
+++ b/.github/workflows/scanner-image-refresh.yml
@@ -53,7 +53,7 @@ jobs:
         run: git checkout --detach "${{ steps.version.outputs.tag }}"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
       # vulnerability database changes, so the image contents stay reproducible
       # apart from the data this job exists to refresh.
       - name: Rebuild and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: apps/scanner
           file: apps/scanner/Dockerfile

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
         with:
-          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
+          enable-cache: false  # no uv cache: v9 defaults to 'auto', and unpruned caching would eat the shared 10 GB Actions budget
       - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -49,7 +49,7 @@ jobs:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
         with:
-          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
+          enable-cache: false  # no uv cache: v9 defaults to 'auto', and unpruned caching would eat the shared 10 GB Actions budget
 
       - name: Verify tag matches package version
         run: |

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
+        with:
+          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
       - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -46,6 +48,8 @@ jobs:
         with:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
+        with:
+          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
 
       - name: Verify tag matches package version
         run: |

--- a/.github/workflows/scanner-publish.yml
+++ b/.github/workflows/scanner-publish.yml
@@ -21,10 +21,10 @@ jobs:
         working-directory: apps/scanner
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
       - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -42,10 +42,10 @@ jobs:
         working-directory: apps/scanner
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
 
       - name: Verify tag matches package version
         run: |
@@ -81,14 +81,14 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/scanner-v}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: apps/scanner
           file: apps/scanner/Dockerfile

--- a/.github/workflows/schemas-publish.yml
+++ b/.github/workflows/schemas-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
         with:
-          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
+          enable-cache: false  # no uv cache: v9 defaults to 'auto', and unpruned caching would eat the shared 10 GB Actions budget
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - 'packages/sdk-python/**'
+      - '.github/workflows/sdk-python-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'packages/sdk-python/**'
+      - '.github/workflows/sdk-python-ci.yml'
 
 concurrency:
   group: sdk-python-ci-${{ github.ref }}

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -22,15 +22,15 @@ jobs:
         working-directory: packages/sdk-python
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/sdk-python-ci.yml
+++ b/.github/workflows/sdk-python-ci.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
+        with:
+          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -17,10 +17,10 @@ jobs:
         working-directory: packages/sdk-python
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
       - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -38,10 +38,10 @@ jobs:
         working-directory: packages/sdk-python
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
 
       - name: Verify tag matches package version
         run: |

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
         with:
-          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
+          enable-cache: false  # no uv cache: v9 defaults to 'auto', and unpruned caching would eat the shared 10 GB Actions budget
       - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
         with:
-          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
+          enable-cache: false  # no uv cache: v9 defaults to 'auto', and unpruned caching would eat the shared 10 GB Actions budget
 
       - name: Verify tag matches package version
         run: |

--- a/.github/workflows/sdk-python-publish.yml
+++ b/.github/workflows/sdk-python-publish.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
+        with:
+          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
       - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
@@ -42,6 +44,8 @@ jobs:
         with:
           python-version: '3.13'
       - uses: astral-sh/setup-uv@v9.0.0  # setup-uv dropped floating major tags (v8+); pin exact
+        with:
+          enable-cache: false  # keep v4's no-cache default; a caching change is out of scope
 
       - name: Verify tag matches package version
         run: |

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - 'packages/sdk-typescript/**'
+      - '.github/workflows/sdk-typescript-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'packages/sdk-typescript/**'
+      - '.github/workflows/sdk-typescript-ci.yml'
 
 concurrency:
   group: sdk-typescript-ci-${{ github.ref }}

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/sdk-typescript-ci.yml
+++ b/.github/workflows/sdk-typescript-ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/sdk-typescript-publish.yml
+++ b/.github/workflows/sdk-typescript-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
Clears the "Node.js 20 is deprecated" GitHub Actions warnings by moving every node20-runtime action in the repo (including transitively, via composites) to a verified node24 release.

## Bumps
| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `astral-sh/setup-uv` | v4 | **v9.0.0** (exact) |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `pnpm/action-setup` | v4 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/upload-pages-artifact` | v3 | v5 |

## Notes
- **`setup-uv` pinned exact `@v9.0.0`**: floating `@v7` is already node24, but `@v8`/`@v9` do not resolve (setup-uv dropped floating major/minor tags in v8), so an exact pin is required to run the latest major. `@v9.0.0` is reproducible and current; the line carries a comment.
- **`upload-pages-artifact@v3 → v5`** is the load-bearing add: `@v3` is a composite that transitively runs `upload-artifact@v4` (node20), so `deploy-docs` still warned. `@v5` embeds `upload-artifact@v7` (node24) and is the lockstep pair to `deploy-pages@v5`. `include-hidden-files: true` preserves v3's include-everything behavior (v5 excludes dotfiles by default; harmless for the Astro/Starlight `dist`, but preserved to avoid any surprise).
- **`pnpm/action-setup@v5`**: all usages are bare; `package.json` sets `packageManager: pnpm@9.15.4`, which v5 reads — no behavior change.
- **`docker/build-push-action@v7`** makes no manifest/provenance change. `pypa/gh-action-pypi-publish@release` is unaffected (a composite wrapping a Docker container; its only nested JS action is `setup-python@v6`, node24) and is left untouched.

Verified: no node20 actions remain in `.github/` (direct or transitive). `actionlint` passes.

## Behavior note (setup-uv cache)
`setup-uv@v9` changes two cache defaults vs `@v4` (`enable-cache` false→auto, `prune-cache` true→false). Left bare, the six uv jobs would flip from no caching to unpruned caching against the shared 10 GB Actions cache budget. Since a caching change is out of scope for a node24 runtime bump, every setup-uv step now sets `enable-cache: false` to hold v4 behavior. Turning on (pruned) uv caching can be a separate, deliberate change.

## Version selection
`setup-uv` is pinned to its newest major (`v9.0.0`, exact) because setup-uv dropped floating tags. The GitHub-owned actions are pinned **one major behind current** (`checkout@v6`, `setup-node@v6`, `setup-python@v6`; `pnpm/action-setup@v5`; latest are v7/v7/v7/v6) — deliberately conservative on first-party actions, matching the pin set hq uses for MCPB release workflows.

## Self-validation
The three per-app CI workflows now include their own path in their `paths:` filter, so this PR's action bumps run on the PR itself (all green) and any future CI-config edit self-validates.