### PR TITLE
Remove Agent Skills from the web index.html SEO shell (#125 follow-up)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,8 +7,8 @@
     <!-- Primary Meta Tags -->
     <title>mpak - The Missing Package Manager for AI</title>
     <meta name="title" content="mpak - The Missing Package Manager for AI" />
-    <meta name="description" content="Install bundles and skills for your AI agent. The package registry for MCP servers and Agent Skills. Think npm for AI." />
-    <meta name="keywords" content="AI, package manager, MCP, Model Context Protocol, agent skills, npm, CLI, developer tools, AI agents, bundles, skills" />
+    <meta name="description" content="Install MCP server bundles for your AI agent. The security-scanned package registry for MCP servers. Think npm for AI." />
+    <meta name="keywords" content="AI, package manager, MCP, Model Context Protocol, MCP servers, npm, CLI, developer tools, AI agents, bundles, MCPB" />
     <meta name="author" content="mpak" />
     <meta name="robots" content="index, follow" />
 
@@ -33,11 +33,11 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.mpak.dev/" />
     <meta property="og:title" content="mpak - The Missing Package Manager for AI" />
-    <meta property="og:description" content="Install bundles and skills for your AI agent. The package registry for MCP servers and Agent Skills." />
+    <meta property="og:description" content="Install MCP server bundles for your AI agent. The security-scanned package registry for MCP servers." />
     <meta property="og:image" content="https://www.mpak.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="mpak - The secure registry for MCP servers and skills" />
+    <meta property="og:image:alt" content="mpak - The secure registry for MCP servers" />
     <meta property="og:site_name" content="mpak" />
     <meta property="og:locale" content="en_US" />
 
@@ -45,9 +45,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://www.mpak.dev/" />
     <meta name="twitter:title" content="mpak - The Missing Package Manager for AI" />
-    <meta name="twitter:description" content="Install bundles and skills for your AI agent. The package registry for MCP servers and Agent Skills." />
+    <meta name="twitter:description" content="Install MCP server bundles for your AI agent. The security-scanned package registry for MCP servers." />
     <meta name="twitter:image" content="https://www.mpak.dev/og-image.png" />
-    <meta name="twitter:image:alt" content="mpak - The secure registry for MCP servers and skills" />
+    <meta name="twitter:image:alt" content="mpak - The secure registry for MCP servers" />
     <meta name="twitter:creator" content="@mpak_dev" />
 
     <!-- Canonical URL -->
@@ -73,7 +73,7 @@
       "alternateName": "mpak - The Missing Package Manager for AI",
       "url": "https://www.mpak.dev",
       "logo": "https://www.mpak.dev/favicon.svg",
-      "description": "Install bundles and skills for your AI agent. The package registry for MCP servers and Agent Skills.",
+      "description": "Install MCP server bundles for your AI agent. The security-scanned package registry for MCP servers.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Any",
       "offers": {
@@ -95,22 +95,17 @@
     <div id="root"></div>
     <noscript>
       <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#e0dce8;">
-        <h1>mpak - The Secure Registry for MCP Servers and Skills</h1>
-        <p>mpak is the open-source package registry for MCP (Model Context Protocol) servers and Agent Skills. Every bundle is scanned with 25 security controls across 5 domains, and trust scores are visible on every package.</p>
-        <h2>Package Types</h2>
-        <ul>
-          <li><strong>Bundles</strong> - Pre-packaged MCP servers that give AI agents new capabilities (database access, API integrations, file operations). Install with: <code>mpak bundle pull @scope/name</code></li>
-          <li><strong>Skills</strong> - Markdown instructions that teach AI agents new behaviors and domain expertise. Install with: <code>mpak skill install @scope/name</code></li>
-        </ul>
+        <h1>mpak - The Secure Registry for MCP Servers</h1>
+        <p>mpak is the open-source package registry for MCP (Model Context Protocol) servers. Every bundle is scanned with 25 security controls across 5 domains, and trust scores are visible on every package.</p>
+        <h2>Bundles</h2>
+        <p>Pre-packaged MCP servers that give AI agents new capabilities (database access, API integrations, file operations). Install with: <code>mpak bundle pull @scope/name</code></p>
         <h2>Get Started</h2>
         <p>Install the CLI: <code>npm install -g @nimblebrain/mpak</code></p>
         <h2>Links</h2>
         <ul>
           <li><a href="https://www.mpak.dev/bundles">Browse Bundles</a></li>
-          <li><a href="https://www.mpak.dev/skills">Browse Skills</a></li>
           <li><a href="https://www.mpak.dev/security">Security</a></li>
           <li><a href="https://www.mpak.dev/publish/bundles">Publish Bundles</a></li>
-          <li><a href="https://www.mpak.dev/publish/skills">Publish Skills</a></li>
           <li><a href="https://www.mpak.dev/about">About</a></li>
           <li><a href="https://docs.mpak.dev">Documentation</a></li>
         </ul>


### PR DESCRIPTION
## Completes the web skills purge

#125 removed skills from `apps/web/src` (components, pages, redirects) but **missed `apps/web/index.html`** — the Vite HTML entry shell. My #125 review missed it too (we both swept `src/`, not the top-level `index.html`).

The shell still advertised skills in **12 places** — all crawler- and `<noscript>`-visible on the live homepage:
- `<meta>` description/keywords, OG + Twitter cards, image alts
- JSON-LD `description`
- the `<noscript>` block: `<h1>...MCP Servers and Skills</h1>`, a "Skills" package type with `mpak skill install @scope/name`, and "Browse Skills" / "Publish Skills" links

All reworded bundle-only. The React SPA itself was already clean.

**Context:** this is live on prod right now (the deployed homepage HTML advertises removed skills). After merge, the web image will be rebuilt + redeployed to prod.