### PR TITLE
Fallback to detected platform for bundle downloads

### DIFF
--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -123,7 +123,8 @@ export class MpakClient {
   }
 
   /**
-   * Get download info for a bundle
+   * Get download info for a bundle.
+   * Falls back to the current platform when a universal artifact is not available.
    */
   async getBundleDownload(
     name: string,
@@ -132,18 +133,25 @@ export class MpakClient {
   ): Promise<DownloadInfo> {
     this.validateScopedName(name);
 
-    const params = new URLSearchParams();
-    if (platform) {
-      params.set('os', platform.os);
-      params.set('arch', platform.arch);
+    const fetchDownload = (selectedPlatform?: PlatformInfo) => {
+      const params = new URLSearchParams();
+      if (selectedPlatform) {
+        params.set('os', selectedPlatform.os);
+        params.set('arch', selectedPlatform.arch);
+      }
+
+      const queryString = params.toString();
+      const url = `${this.registryUrl}/v1/bundles/${name}/versions/${version}/download${queryString ? `?${queryString}` : ''}`;
+
+      return this.fetchWithTimeout(url, {
+        headers: { Accept: 'application/json' },
+      });
+    };
+
+    let response = await fetchDownload(platform);
+    if (response.status === 404 && !platform) {
+      response = await fetchDownload(MpakClient.detectPlatform());
     }
-
-    const queryString = params.toString();
-    const url = `${this.registryUrl}/v1/bundles/${name}/versions/${version}/download${queryString ? `?${queryString}` : ''}`;
-
-    const response = await this.fetchWithTimeout(url, {
-      headers: { Accept: 'application/json' },
-    });
 
     if (response.status === 404) {
       throw new MpakNotFoundError(`${name}@${version}`);

--- a/packages/sdk-typescript/tests/client.test.ts
+++ b/packages/sdk-typescript/tests/client.test.ts
@@ -235,6 +235,30 @@ describe('MpakClient', () => {
       expect(calledUrl).toContain('os=linux');
       expect(calledUrl).toContain('arch=x64');
     });
+
+    it('falls back to detected platform when no universal artifact exists', async () => {
+      const client = new MpakClient();
+      fetchMock
+        .mockResolvedValueOnce(mockResponse('', { status: 404 }))
+        .mockResolvedValueOnce(
+          mockResponse({
+            url: 'https://example.com',
+            bundle: {
+              name: '@test/bundle',
+              version: '1.0.0',
+              platform: { os: 'darwin', arch: 'arm64' },
+              sha256: '',
+              size: 0,
+            },
+          }),
+        );
+
+      await client.getBundleDownload('@test/bundle', '1.0.0');
+
+      const fallbackUrl = fetchMock.mock.calls[1]?.[0] as string;
+      expect(fallbackUrl).toContain('os=');
+      expect(fallbackUrl).toContain('arch=');
+    });
   });
 
   describe('downloadContent', () => {


### PR DESCRIPTION
Fixes #149.

## Summary
- Preserve the existing no-platform request path so universal `any/any` artifacts can still resolve.
- When no platform was provided and the universal request returns 404, retry with `MpakClient.detectPlatform()`.
- Add a unit test covering the fallback path for platform-scoped bundles.

## Validation
- `git diff --check`

I attempted to run `pnpm install --frozen-lockfile` and `pnpm --filter @nimblebrain/mpak-sdk test`, but the workspace-wide dependency install repeatedly stalled on unrelated monorepo package downloads/retries before linking `node_modules`, so the SDK test command could not be executed in this environment.
