### PR TITLE
fix(sdk): auto-detect platform in getBundleDownload

### DIFF
--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -122,39 +122,42 @@ export class MpakClient {
     return response.json() as Promise<VersionDetail>;
   }
 
-  /**
-   * Get download info for a bundle
-   */
-  async getBundleDownload(
-    name: string,
-    version: string,
-    platform?: PlatformInfo,
-  ): Promise<DownloadInfo> {
-    this.validateScopedName(name);
+/**
+ * Get download info for a bundle
+ */
+async getBundleDownload(
+  name: string,
+  version: string,
+  platform?: PlatformInfo,
+): Promise<DownloadInfo> {
+  this.validateScopedName(name);
 
-    const params = new URLSearchParams();
-    if (platform) {
-      params.set('os', platform.os);
-      params.set('arch', platform.arch);
-    }
+  // NEW: Use the provided platform or detect the current one
+  const resolvedPlatform = platform ?? MpakClient.detectPlatform();
 
-    const queryString = params.toString();
-    const url = `${this.registryUrl}/v1/bundles/${name}/versions/${version}/download${queryString ? `?${queryString}` : ''}`;
+  const params = new URLSearchParams();
 
-    const response = await this.fetchWithTimeout(url, {
-      headers: { Accept: 'application/json' },
-    });
+  // CHANGED: Always use the resolved platform
+  params.set('os', resolvedPlatform.os);
+  params.set('arch', resolvedPlatform.arch);
 
-    if (response.status === 404) {
-      throw new MpakNotFoundError(`${name}@${version}`);
-    }
+  const queryString = params.toString();
+  const url = `${this.registryUrl}/v1/bundles/${name}/versions/${version}/download${queryString ? `?${queryString}` : ''}`;
 
-    if (!response.ok) {
-      throw new MpakNetworkError(`Failed to get bundle download: HTTP ${response.status}`);
-    }
+  const response = await this.fetchWithTimeout(url, {
+    headers: { Accept: 'application/json' },
+  });
 
-    return response.json() as Promise<DownloadInfo>;
+  if (response.status === 404) {
+    throw new MpakNotFoundError(`${name}@${version}`);
   }
+
+  if (!response.ok) {
+    throw new MpakNetworkError(`Failed to get bundle download: HTTP ${response.status}`);
+  }
+
+  return response.json() as Promise<DownloadInfo>;
+}
 
   // ===========================================================================
   // MCP Registry (ServerDetail) API

--- a/packages/sdk-typescript/tests/client.test.ts
+++ b/packages/sdk-typescript/tests/client.test.ts
@@ -234,8 +234,34 @@ describe('MpakClient', () => {
       const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
       expect(calledUrl).toContain('os=linux');
       expect(calledUrl).toContain('arch=x64');
-    });
-  });
+      });
+
+      it('auto-detects platform when none is provided', async () => {
+        const client = new MpakClient();
+
+        fetchMock.mockResolvedValueOnce(
+          mockResponse({
+            url: 'https://example.com',
+            bundle: {
+              name: '@test/bundle',
+              version: '1.0.0',
+              platform: {},
+              sha256: '',
+              size: 0,
+            },
+            expires_at: '2024-01-02T00:00:00Z',
+          }),
+        );
+
+        await client.getBundleDownload('@test/bundle', '1.0.0');
+
+        const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+
+        expect(calledUrl).toContain('os=');
+        expect(calledUrl).toContain('arch=');
+      });
+
+      });
 
   describe('downloadContent', () => {
     it('downloads and verifies SHA-256', async () => {


### PR DESCRIPTION
Summary

- Updated getBundleDownload() to automatically detect the current platform when one is not provided by the caller. This - ensures the request includes the required os and arch parameters for platform-specific bundles.

Changes

- Added automatic platform detection using MpakClient.detectPlatform() when no platform is supplied.
- Updated getBundleDownload() to include the detected os and arch values in the download request.
- Added a unit test verifying that platform detection occurs automatically when the platform parameter is omitted.