### PR TITLE
Give mirrored packages a README, and make os-universal builds downloadable

### DIFF
--- a/apps/registry/src/db/repositories/package.repository.ts
+++ b/apps/registry/src/db/repositories/package.repository.ts
@@ -699,6 +699,11 @@ export class PackageRepository {
       update: {
         manifest: data.manifest as Prisma.InputJsonValue,
         prerelease: data.prerelease ?? false,
+        // Both callers reach the update path holding a README they paid for —
+        // the publish route only fetches one when the stored value is empty,
+        // and ingest reads it out of an archive it already downloaded. Omitting
+        // it here made both of those spends unconditionally wasted.
+        ...(data.readme !== undefined ? { readme: data.readme } : {}),
         ...(data.publishMethod ? { publishMethod: data.publishMethod } : {}),
         ...(data.provenanceRepository ? { provenanceRepository: data.provenanceRepository } : {}),
         ...(data.provenanceSha ? { provenanceSha: data.provenanceSha } : {}),

--- a/apps/registry/src/routes/v1/bundles.ts
+++ b/apps/registry/src/routes/v1/bundles.ts
@@ -75,11 +75,17 @@ function isValidScopedPackageName(name: string): boolean {
  *
  * The widening from exact-match matters because `arch: 'any'` is a real stored
  * value, not a query convention: an artifact named `server-linux.mcpb` declares
- * an OS and no architecture, and is recorded as `linux/any`. Callers never ask
- * for it by that name — the SDK's `detectPlatform` reports the concrete runtime
- * (`linux`/`x64`) and the query schema admits no `any` — so under exact-match
- * such a build is addressable by nobody, and a package whose every artifact has
- * that shape 404s on every download while still appearing in the catalog.
+ * an OS and no architecture, and is recorded as `linux/any`. A caller on a
+ * supported platform asks for its concrete pair — `linux`/`x64` — so under
+ * exact-match that build is reachable by nobody, and a package whose every
+ * artifact has that shape 404s on every download while still appearing in the
+ * catalog.
+ *
+ * Asking for `arch=any` directly is not the way in either: the query schema
+ * admits only `x64` and `arm64`, so such a request is rejected before this
+ * function runs. That rejection also strands the SDK on any platform outside
+ * those enums, which is a separate defect in the schema, not in this
+ * resolution.
  *
  * Preference order is specificity: an arch-specific build beats one that merely
  * claims to run anywhere on that OS, which in turn beats a fully portable one.

--- a/apps/registry/src/routes/v1/bundles.ts
+++ b/apps/registry/src/routes/v1/bundles.ts
@@ -70,7 +70,19 @@ function isValidScopedPackageName(name: string): boolean {
  *
  * - Neither os nor arch → return the any/any (universal) artifact, or null
  * - Only one of os/arch → throws BadRequestError
- * - Both os and arch → return exact match, or null
+ * - Both os and arch → exact match, else the os-universal build, else the
+ *   fully universal one, else null
+ *
+ * The widening from exact-match matters because `arch: 'any'` is a real stored
+ * value, not a query convention: an artifact named `server-linux.mcpb` declares
+ * an OS and no architecture, and is recorded as `linux/any`. Callers never ask
+ * for it by that name — the SDK's `detectPlatform` reports the concrete runtime
+ * (`linux`/`x64`) and the query schema admits no `any` — so under exact-match
+ * such a build is addressable by nobody, and a package whose every artifact has
+ * that shape 404s on every download while still appearing in the catalog.
+ *
+ * Preference order is specificity: an arch-specific build beats one that merely
+ * claims to run anywhere on that OS, which in turn beats a fully portable one.
  */
 function resolveArtifact(artifacts: Artifact[], os?: string, arch?: string): Artifact | null {
   if ((os && !arch) || (!os && arch)) {
@@ -78,7 +90,12 @@ function resolveArtifact(artifacts: Artifact[], os?: string, arch?: string): Art
   }
 
   if (os && arch) {
-    return artifacts.find((a) => a.os === os && a.arch === arch) ?? null;
+    return (
+      artifacts.find((a) => a.os === os && a.arch === arch) ??
+      artifacts.find((a) => a.os === os && a.arch === 'any') ??
+      artifacts.find((a) => a.os === 'any' && a.arch === 'any') ??
+      null
+    );
   }
 
   // No platform params: return universal artifact only

--- a/apps/registry/src/services/mcp-registry/bundle.ts
+++ b/apps/registry/src/services/mcp-registry/bundle.ts
@@ -28,6 +28,8 @@ export interface BundleInspection {
   declaredTools: number;
   hasLockfile: boolean;
   sourceFileCount: number;
+  /** Root README as shipped in the archive, or null if it ships none. */
+  readme: string | null;
 }
 
 export interface DownloadedBundle {
@@ -76,6 +78,21 @@ export class BundleVerificationError extends Error {
  * it is an attempt to make us allocate.
  */
 const MAX_MANIFEST_BYTES = 4 * 1024 * 1024;
+
+/**
+ * A README renders into a package page, so the bound is about what a browser is
+ * asked to display as much as what the decompression allocates. Anything past
+ * this is not prose. Over the cap the README is dropped, not an error: a
+ * ridiculous README is no reason to refuse to mirror a valid bundle.
+ */
+const MAX_README_BYTES = 512 * 1024;
+
+/**
+ * Root README filenames, best first. Case is compared insensitively, so this
+ * covers `readme.md` too. Only the archive root is considered — a README under
+ * `docs/` or `node_modules/` describes something other than this server.
+ */
+const README_NAMES = ['README.md', 'README.markdown', 'README.rst', 'README.txt', 'README'];
 
 export class NotABundleError extends Error {
   constructor(message: string) {
@@ -160,12 +177,35 @@ export function inspectBundle(bundlePath: string): BundleInspection {
 
   let sourceFileCount = 0;
   let hasLockfile = false;
+  let readmeEntry: AdmZip.IZipEntry | undefined;
+  let readmeRank = README_NAMES.length;
   for (const entry of entries) {
     if (entry.isDirectory) continue;
     const base = entry.entryName.split('/').pop() ?? '';
     if (LOCKFILES.has(base)) hasLockfile = true;
     const ext = path.extname(base).toLowerCase();
     if (SOURCE_EXTENSIONS.includes(ext)) sourceFileCount += 1;
+
+    // Root only: `entryName` is the full path, so a root file has no separator.
+    if (!entry.entryName.includes('/')) {
+      const rank = README_NAMES.findIndex((n) => n.toLowerCase() === base.toLowerCase());
+      if (rank !== -1 && rank < readmeRank) {
+        readmeRank = rank;
+        readmeEntry = entry;
+      }
+    }
+  }
+
+  // Same declared-size discipline as the manifest, and for the same reason:
+  // the header size is available before anything is allocated.
+  let readme: string | null = null;
+  if (readmeEntry && readmeEntry.header.size <= MAX_README_BYTES) {
+    try {
+      readme = zip.readAsText(readmeEntry) || null;
+    } catch {
+      // Unreadable README, readable bundle. The bundle is still worth mirroring.
+      readme = null;
+    }
   }
 
   const declaredTools = Array.isArray(manifest.tools) ? manifest.tools.length : 0;
@@ -180,6 +220,7 @@ export function inspectBundle(bundlePath: string): BundleInspection {
     declaredTools,
     hasLockfile,
     sourceFileCount,
+    readme,
   };
 }
 

--- a/apps/registry/src/services/mcp-registry/bundle.ts
+++ b/apps/registry/src/services/mcp-registry/bundle.ts
@@ -202,7 +202,11 @@ export function inspectBundle(bundlePath: string): BundleInspection {
   let readme: string | null = null;
   if (readmeEntry && readmeEntry.header.size <= MAX_README_BYTES) {
     try {
-      readme = zip.readAsText(readmeEntry) || null;
+      // Whitespace is absence, not content. This is the preferred source, so a
+      // blank file here would otherwise outrank the repository fallback and
+      // render as an empty block — the symptom the whole change exists to fix.
+      const text = zip.readAsText(readmeEntry);
+      readme = text.trim() ? text : null;
     } catch {
       // Unreadable README, readable bundle. The bundle is still worth mirroring.
       readme = null;

--- a/apps/registry/src/services/mcp-registry/bundle.ts
+++ b/apps/registry/src/services/mcp-registry/bundle.ts
@@ -186,8 +186,9 @@ export function inspectBundle(bundlePath: string): BundleInspection {
     const ext = path.extname(base).toLowerCase();
     if (SOURCE_EXTENSIONS.includes(ext)) sourceFileCount += 1;
 
-    // Root only: `entryName` is the full path, so a root file has no separator.
-    if (!entry.entryName.includes('/')) {
+    // Root only: `entryName` is the full path, so a root file has no separator
+    // once the `./` some archivers prefix every entry with is removed.
+    if (!entry.entryName.replace(/^\.\//, '').includes('/')) {
       const rank = README_NAMES.findIndex((n) => n.toLowerCase() === base.toLowerCase());
       if (rank !== -1 && rank < readmeRank) {
         readmeRank = rank;

--- a/apps/registry/src/services/mcp-registry/ingest.ts
+++ b/apps/registry/src/services/mcp-registry/ingest.ts
@@ -28,6 +28,7 @@ import {
 import type { McpRegistryClient } from './client.js';
 import type { MappedArtifact, MappedServer, RejectReason } from './mapper.js';
 import { mapServer, mcpbPackages } from './mapper.js';
+import { fetchGithubReadme, releaseTagFromAssetUrl } from './readme.js';
 import { officialMeta, type UpstreamServerEntry } from './types.js';
 
 /**
@@ -431,6 +432,7 @@ async function ingestServer(
     scanability: string;
     manifest: Record<string, unknown>;
     serverType: string;
+    readme: string | null;
   }> = [];
 
   // Registered the instant a temp file exists, separately from `downloads`,
@@ -498,6 +500,7 @@ async function ingestServer(
           scanability: bundle.inspection.scanability,
           manifest: bundle.inspection.manifest,
           serverType: bundle.inspection.serverType,
+          readme: bundle.inspection.readme,
         });
       } catch (err) {
         // A per-artifact failure abandons the whole server rather than
@@ -551,6 +554,21 @@ async function ingestServer(
     const primary = downloads[0];
     if (!primary) return { matched: true, skipReason: 'bad-identifier', upstreamUpdatedAt: at };
 
+    // A README the archive shipped wins: it is the description of the exact
+    // bytes whose digest was verified. Any artifact in the platform set will
+    // do — they are the same server built for different targets, and a
+    // Windows-only build is no less authoritative about what the server is.
+    //
+    // Resolved out here, before the transaction, because the fallback is a
+    // network call and nothing is worth holding a write transaction open for.
+    let readme = downloads.find((d) => d.readme)?.readme ?? null;
+    if (!readme && server.githubRepo) {
+      readme = await fetchGithubReadme({
+        githubRepo: server.githubRepo,
+        ref: releaseTagFromAssetUrl(primary.artifact.sourceUrl),
+      });
+    }
+
     let written: { packageCreated: boolean; versionCreated: boolean; versionId: string };
     try {
       written = await runInTransaction(async (tx) => {
@@ -602,6 +620,7 @@ async function ingestServer(
             publishedByEmail: null,
             publishMethod: 'ingest',
             provenanceRepository: server.githubRepo,
+            readme: readme ?? undefined,
             serverJson: entry.server,
           },
           tx,

--- a/apps/registry/src/services/mcp-registry/readme.ts
+++ b/apps/registry/src/services/mcp-registry/readme.ts
@@ -17,16 +17,27 @@
  */
 
 /**
- * Same order of preference as the in-bundle lookup. Kept short on purpose: a
- * repository with no README costs one 404 per name per ref, and every name past
- * these is rare enough that finding it is not worth charging every miss for.
+ * A shorter prefix of the in-bundle preference order, plus the lowercase
+ * spelling. Kept short on purpose: a repository with no README costs one 404
+ * per name per ref, and every name past these is rare enough that finding it is
+ * not worth charging every miss for.
+ *
+ * The lowercase entry is not redundant with the in-bundle lookup's
+ * case-insensitive compare. Here the name is a URL path on a case-sensitive
+ * host — `readme.md` is a 404 against a repository whose file is `README.md`
+ * and vice versa — so each spelling that matters has to be asked for.
  */
-const README_PATHS = ['README.md', 'README.rst', 'README.txt', 'README'];
+const README_PATHS = ['README.md', 'readme.md', 'README.rst', 'README.txt', 'README'];
 
 /** Matches the in-bundle cap; the destination column and page are the same. */
 const MAX_README_BYTES = 512 * 1024;
 
-const DEFAULT_TIMEOUT_MS = 10_000;
+/**
+ * Not caller-configurable, unlike the artifact download's. That one bounds a
+ * transfer whose size varies by orders of magnitude; this is a single small
+ * file, so one bound fits every call site.
+ */
+const TIMEOUT_MS = 10_000;
 
 /**
  * Recover the git ref an MCPB artifact was published at.
@@ -42,9 +53,9 @@ export function releaseTagFromAssetUrl(assetUrl: string | undefined): string | u
   return m?.[1] ? decodeURIComponent(m[1]) : undefined;
 }
 
-async function fetchOne(url: string, timeoutMs: number): Promise<string | null> {
+async function fetchOne(url: string): Promise<string | null> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
     const res = await fetch(url, {
       headers: { 'User-Agent': 'mpak-registry' },
@@ -77,15 +88,18 @@ async function fetchOne(url: string, timeoutMs: number): Promise<string | null> 
 export async function fetchGithubReadme(options: {
   githubRepo: string;
   ref?: string;
-  timeoutMs?: number;
 }): Promise<string | null> {
   const { githubRepo, ref } = options;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  // `githubRepo` reaches here from the mapper's `githubSlug`, which is already
-  // anchored to github.com and rejects path segments. Re-checking the shape
-  // keeps that guarantee local to the function that builds a URL from it.
-  if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(githubRepo)) return null;
+  // `githubRepo` reaches here from the mapper's `githubSlug`, which regex-matches
+  // an upstream-controlled URL rather than parsing it, so `github.com/../..`
+  // does arrive here as `../..`. A shape check alone admits that — both
+  // segments are legal characters — so `..` is excluded explicitly, the same
+  // way it is for the ref below.
+  const segments = githubRepo.split('/');
+  if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(githubRepo) || segments.includes('..')) {
+    return null;
+  }
 
   // `HEAD` resolves to the default branch whatever it is named. It is the
   // fallback rather than the first choice because it drifts away from the
@@ -99,10 +113,7 @@ export async function fetchGithubReadme(options: {
     // derived from an upstream-controlled artifact URL.
     if (!/^[A-Za-z0-9._/-]+$/.test(r) || r.split('/').includes('..')) continue;
     for (const p of README_PATHS) {
-      const text = await fetchOne(
-        `https://raw.githubusercontent.com/${githubRepo}/${r}/${p}`,
-        timeoutMs,
-      );
+      const text = await fetchOne(`https://raw.githubusercontent.com/${githubRepo}/${r}/${p}`);
       if (text) return text;
     }
   }

--- a/apps/registry/src/services/mcp-registry/readme.ts
+++ b/apps/registry/src/services/mcp-registry/readme.ts
@@ -68,8 +68,12 @@ async function fetchOne(url: string): Promise<string | null> {
     const declared = Number(res.headers.get('content-length'));
     if (Number.isFinite(declared) && declared > MAX_README_BYTES) return null;
 
+    // Measured in bytes, not `text.length`: that counts UTF-16 code units, so
+    // for non-ASCII prose it would admit several times the stated cap while
+    // claiming to enforce it. The in-bundle side reads a byte count off the
+    // zip header, and this is the same bound.
     const text = await res.text();
-    if (text.length > MAX_README_BYTES) return null;
+    if (Buffer.byteLength(text) > MAX_README_BYTES) return null;
     return text.trim() ? text : null;
   } catch {
     return null;

--- a/apps/registry/src/services/mcp-registry/readme.ts
+++ b/apps/registry/src/services/mcp-registry/readme.ts
@@ -1,0 +1,110 @@
+/**
+ * Second source for a mirrored package's README.
+ *
+ * The bundle itself is the first source and the better one: it is the exact
+ * archive whose digest was verified, so its README describes the bytes mpak
+ * stored. But only some MCPB bundles ship a root README, and a package page
+ * with an empty body reads as an empty package. For the rest, the repository
+ * upstream declares is the only description that exists.
+ *
+ * This deliberately uses `raw.githubusercontent.com` rather than the GitHub
+ * API. The API is rate-limited to 60 requests/hour for unauthenticated callers,
+ * and the registry holds no token — that budget is shared with repo-stat
+ * fetches and, more importantly, with claim verification, which is a
+ * user-facing flow. A nightly run over the whole upstream catalog would consume
+ * it in the first minute and starve them. The raw host is a CDN and is not
+ * charged against it.
+ */
+
+/**
+ * Same order of preference as the in-bundle lookup. Kept short on purpose: a
+ * repository with no README costs one 404 per name per ref, and every name past
+ * these is rare enough that finding it is not worth charging every miss for.
+ */
+const README_PATHS = ['README.md', 'README.rst', 'README.txt', 'README'];
+
+/** Matches the in-bundle cap; the destination column and page are the same. */
+const MAX_README_BYTES = 512 * 1024;
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Recover the git ref an MCPB artifact was published at.
+ *
+ * Upstream MCPB identifiers are overwhelmingly GitHub release-asset URLs, which
+ * carry the tag. Reading the README at that tag rather than at the default
+ * branch keeps it describing the version being mirrored, which is the same
+ * property the publish path gets from its release tag.
+ */
+export function releaseTagFromAssetUrl(assetUrl: string | undefined): string | undefined {
+  if (!assetUrl) return undefined;
+  const m = /^https:\/\/github\.com\/[^/]+\/[^/]+\/releases\/download\/([^/]+)\//.exec(assetUrl);
+  return m?.[1] ? decodeURIComponent(m[1]) : undefined;
+}
+
+async function fetchOne(url: string, timeoutMs: number): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'mpak-registry' },
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+
+    // Content-Length is advisory here, so the body is still bounded below. This
+    // just avoids reading a large one at all when the host is honest about it.
+    const declared = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declared) && declared > MAX_README_BYTES) return null;
+
+    const text = await res.text();
+    if (text.length > MAX_README_BYTES) return null;
+    return text.trim() ? text : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch a README for `owner/repo`, preferring the ref the artifact shipped at.
+ *
+ * Best-effort by construction: every failure returns null. A mirrored bundle
+ * with no description is worse than one with a description, but far better than
+ * a nightly run that abandons a server because someone's repository 404s.
+ */
+export async function fetchGithubReadme(options: {
+  githubRepo: string;
+  ref?: string;
+  timeoutMs?: number;
+}): Promise<string | null> {
+  const { githubRepo, ref } = options;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  // `githubRepo` reaches here from the mapper's `githubSlug`, which is already
+  // anchored to github.com and rejects path segments. Re-checking the shape
+  // keeps that guarantee local to the function that builds a URL from it.
+  if (!/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(githubRepo)) return null;
+
+  // `HEAD` resolves to the default branch whatever it is named. It is the
+  // fallback rather than the first choice because it drifts away from the
+  // mirrored version over time.
+  const refs = ref ? [ref, 'HEAD'] : ['HEAD'];
+
+  for (const r of refs) {
+    // A ref goes into the URL path unescaped, because a branch ref legitimately
+    // contains `/` and percent-encoding it would not resolve. `..` is therefore
+    // excluded explicitly rather than relied on to be absent: the ref is
+    // derived from an upstream-controlled artifact URL.
+    if (!/^[A-Za-z0-9._/-]+$/.test(r) || r.split('/').includes('..')) continue;
+    for (const p of README_PATHS) {
+      const text = await fetchOne(
+        `https://raw.githubusercontent.com/${githubRepo}/${r}/${p}`,
+        timeoutMs,
+      );
+      if (text) return text;
+    }
+  }
+  return null;
+}

--- a/apps/registry/tests/bundles.test.ts
+++ b/apps/registry/tests/bundles.test.ts
@@ -467,6 +467,89 @@ describe('Bundle Routes', () => {
       expect(body.bundle.platform).toEqual({ os: 'any', arch: 'any' });
     });
 
+    it('falls back to the os-universal build when no arch-specific one exists', async () => {
+      // `linux/any` is what an artifact named `server-linux.mcpb` maps to. No
+      // caller can ask for it directly — the SDK reports the concrete arch and
+      // the query schema has no `any` — so without this fallback the build is
+      // addressable by nobody.
+      const osUniversal = {
+        ...mockArtifact,
+        id: 'art-linux-any',
+        os: 'linux',
+        arch: 'any',
+        storagePath: '@test/mcp-server/1.0.0/linux-any.mcpb',
+      };
+      packageRepo.findByName.mockResolvedValue(mockPackage);
+      packageRepo.findVersionWithArtifacts.mockResolvedValue({
+        ...mockVersion,
+        artifacts: [osUniversal],
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/@test/mcp-server/versions/1.0.0/download?os=linux&arch=x64',
+        headers: { accept: 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).bundle.platform).toEqual({ os: 'linux', arch: 'any' });
+    });
+
+    it('prefers the arch-specific build over the os-universal one', async () => {
+      packageRepo.findByName.mockResolvedValue(mockPackage);
+      packageRepo.findVersionWithArtifacts.mockResolvedValue({
+        ...mockVersion,
+        artifacts: [
+          { ...mockArtifact, id: 'art-linux-any', os: 'linux', arch: 'any' },
+          mockArtifact, // linux/x64
+        ],
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/@test/mcp-server/versions/1.0.0/download?os=linux&arch=x64',
+        headers: { accept: 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).bundle.platform).toEqual({ os: 'linux', arch: 'x64' });
+    });
+
+    it('falls back to the fully universal build for an unrelated platform', async () => {
+      packageRepo.findByName.mockResolvedValue(mockPackage);
+      packageRepo.findVersionWithArtifacts.mockResolvedValue({
+        ...mockVersion,
+        artifacts: [{ ...mockArtifact, id: 'art-any', os: 'any', arch: 'any' }],
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/@test/mcp-server/versions/1.0.0/download?os=win32&arch=arm64',
+        headers: { accept: 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).bundle.platform).toEqual({ os: 'any', arch: 'any' });
+    });
+
+    it('still 404s when the requested OS has no build at all', async () => {
+      // The fallback widens reach without making every request succeed: a
+      // linux-only package must not hand a win32 caller a linux binary.
+      packageRepo.findByName.mockResolvedValue(mockPackage);
+      packageRepo.findVersionWithArtifacts.mockResolvedValue({
+        ...mockVersion,
+        artifacts: [{ ...mockArtifact, id: 'art-linux-any', os: 'linux', arch: 'any' }],
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/@test/mcp-server/versions/1.0.0/download?os=win32&arch=x64',
+        headers: { accept: 'application/json' },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+
     it('returns 404 when no platform params and no any/any artifact', async () => {
       packageRepo.findByName.mockResolvedValue(mockPackage);
       packageRepo.findVersionWithArtifacts.mockResolvedValue(mockVersionWithArtifacts);

--- a/apps/registry/tests/mcp-registry-bundle.test.ts
+++ b/apps/registry/tests/mcp-registry-bundle.test.ts
@@ -169,6 +169,11 @@ describe('inspectBundle', () => {
     expect(inspectBundle(p).readme).toBeNull();
   });
 
+  it('finds a root README in an archive that prefixes entries with ./', () => {
+    const p = writeTemp(buildBundle({ files: { './README.md': '# Dot-slash' } }));
+    expect(inspectBundle(p).readme).toBe('# Dot-slash');
+  });
+
   it('prefers README.md over other root README spellings', () => {
     const p = writeTemp(
       buildBundle({ files: { 'README.txt': 'plain text', 'README.md': '# markdown' } }),

--- a/apps/registry/tests/mcp-registry-bundle.test.ts
+++ b/apps/registry/tests/mcp-registry-bundle.test.ts
@@ -138,6 +138,60 @@ describe('inspectBundle', () => {
     const p = writeTemp(zip.toBuffer());
     expect(() => inspectBundle(p)).toThrow(NotABundleError);
   });
+
+  it('extracts a root README, which is the description of the verified bytes', () => {
+    const p = writeTemp(buildBundle({ files: { 'README.md': '# Widget\n\nDoes things.' } }));
+    expect(inspectBundle(p).readme).toBe('# Widget\n\nDoes things.');
+  });
+
+  it('matches a README regardless of case', () => {
+    const p = writeTemp(buildBundle({ files: { 'readme.md': 'lowercase' } }));
+    expect(inspectBundle(p).readme).toBe('lowercase');
+  });
+
+  it('reports no README when the bundle ships none', () => {
+    const p = writeTemp(buildBundle({ files: { 'main.py': 'print(1)' } }));
+    expect(inspectBundle(p).readme).toBeNull();
+  });
+
+  it('ignores a README that is not at the archive root', () => {
+    // A README under node_modules/ or docs/ describes a dependency or a
+    // subsystem, not this server, and rendering it on the package page would
+    // be actively misleading. Most bundles vendor dozens of them.
+    const p = writeTemp(
+      buildBundle({
+        files: {
+          'node_modules/left-pad/README.md': '# left-pad',
+          'docs/README.md': '# docs',
+        },
+      }),
+    );
+    expect(inspectBundle(p).readme).toBeNull();
+  });
+
+  it('prefers README.md over other root README spellings', () => {
+    const p = writeTemp(
+      buildBundle({ files: { 'README.txt': 'plain text', 'README.md': '# markdown' } }),
+    );
+    expect(inspectBundle(p).readme).toBe('# markdown');
+  });
+
+  it('drops an absurdly large README rather than refusing the bundle', () => {
+    // A README renders into a page, so the bound is about what a browser is
+    // asked to display. Unlike the manifest cap this is not fatal: an absurd
+    // README is no reason to refuse to mirror an otherwise valid bundle.
+    const zip = new AdmZip();
+    zip.addFile(
+      'manifest.json',
+      Buffer.from(JSON.stringify({ manifest_version: '0.3', server: { type: 'python' } })),
+    );
+    zip.addFile('README.md', Buffer.alloc(1024 * 1024, 0x61));
+    const p = writeTemp(zip.toBuffer());
+
+    const result = inspectBundle(p);
+    expect(result.readme).toBeNull();
+    expect(result.serverType).toBe('python');
+  });
 });
 
 describe('downloadAndVerify', () => {

--- a/apps/registry/tests/mcp-registry-bundle.test.ts
+++ b/apps/registry/tests/mcp-registry-bundle.test.ts
@@ -169,6 +169,14 @@ describe('inspectBundle', () => {
     expect(inspectBundle(p).readme).toBeNull();
   });
 
+  it('treats a whitespace-only README as absent, so the fallback still runs', () => {
+    // Symmetric with the repository source. This is the *preferred* source, so
+    // a blank file here outranks the fallback and renders as an empty block —
+    // the symptom this whole change exists to fix.
+    const p = writeTemp(buildBundle({ files: { 'README.md': '   \n\n  ' } }));
+    expect(inspectBundle(p).readme).toBeNull();
+  });
+
   it('finds a root README in an archive that prefixes entries with ./', () => {
     const p = writeTemp(buildBundle({ files: { './README.md': '# Dot-slash' } }));
     expect(inspectBundle(p).readme).toBe('# Dot-slash');

--- a/apps/registry/tests/mcp-registry-ingest.test.ts
+++ b/apps/registry/tests/mcp-registry-ingest.test.ts
@@ -61,8 +61,12 @@ function upstreamEntry(
 }
 
 /** Upstream that serves one page of the given entries, then the artifact bytes. */
-function fakeUpstream(entries: unknown[], artifact: Buffer | null = BUNDLE) {
-  const calls = { list: 0, download: 0 };
+function fakeUpstream(
+  entries: unknown[],
+  artifact: Buffer | null = BUNDLE,
+  githubReadme: string | null = null,
+) {
+  const calls = { list: 0, download: 0, readme: 0 };
 
   const listFetch = vi.fn().mockImplementation(() => {
     calls.list += 1;
@@ -74,7 +78,19 @@ function fakeUpstream(entries: unknown[], artifact: Buffer | null = BUNDLE) {
     );
   });
 
-  const downloadFetch = vi.fn().mockImplementation(() => {
+  const downloadFetch = vi.fn().mockImplementation((input: string | URL) => {
+    // The README fallback reads a different host than the artifact does, and
+    // counting the two together would make the download assertions — which are
+    // how these tests prove idempotence — mean something else.
+    if (String(input).startsWith('https://raw.githubusercontent.com/')) {
+      calls.readme += 1;
+      return Promise.resolve(
+        githubReadme && String(input).endsWith('/README.md')
+          ? new Response(githubReadme, { status: 200 })
+          : new Response('404: Not Found', { status: 404 }),
+      );
+    }
+
     calls.download += 1;
     if (!artifact) return Promise.resolve(new Response('gone', { status: 404 }));
     return Promise.resolve(
@@ -244,6 +260,67 @@ describe('runIngest', () => {
     expect(repoMocks.upsertVersion.mock.calls[0]?.[1]).toMatchObject({
       publishMethod: 'ingest',
     });
+  });
+
+  it('records the README the archive shipped, without asking GitHub', async () => {
+    // The in-bundle README describes the exact bytes whose digest was verified,
+    // so it wins outright — and costs nothing, since the archive is already open
+    // for the manifest.
+    const withReadme = new AdmZip(BUNDLE);
+    withReadme.addFile('README.md', Buffer.from('# Widget\n\nFrom the bundle.'));
+    const buf = withReadme.toBuffer();
+    const sha = createHash('sha256').update(buf).digest('hex');
+
+    const { client, calls } = fakeUpstream(
+      [
+        upstreamEntry({
+          packages: [{ registryType: 'mcpb', identifier: BUNDLE_URL, fileSha256: sha }],
+        }),
+      ],
+      buf,
+      '# Widget\n\nFrom GitHub.',
+    );
+
+    await runIngest(baseOptions(client, fakePrisma(state)));
+
+    expect(repoMocks.upsertVersion.mock.calls[0]?.[1]).toMatchObject({
+      readme: '# Widget\n\nFrom the bundle.',
+    });
+    expect(calls.readme).toBe(0);
+  });
+
+  it('falls back to the repository README when the archive ships none', async () => {
+    // Most MCPB bundles ship no README, and a package page with an empty body
+    // reads as an empty package. The declared repository is the only
+    // description that exists for those.
+    const { client, calls } = fakeUpstream([upstreamEntry()], BUNDLE, '# Widget\n\nFrom GitHub.');
+
+    await runIngest(baseOptions(client, fakePrisma(state)));
+
+    expect(repoMocks.upsertVersion.mock.calls[0]?.[1]).toMatchObject({
+      readme: '# Widget\n\nFrom GitHub.',
+    });
+    // Read at the tag the artifact was published at, not the default branch.
+    expect(calls.readme).toBeGreaterThan(0);
+  });
+
+  it('ingests a server with no README from either source', async () => {
+    // Neither source having one is normal, not a failure. The bundle is still
+    // worth mirroring — the whole point is that it is hash-verified.
+    const { client } = fakeUpstream([upstreamEntry()]);
+
+    const result = await runIngest(baseOptions(client, fakePrisma(state)));
+
+    expect(result.versionsCreated).toBe(1);
+    expect(repoMocks.upsertVersion.mock.calls[0]?.[1]?.readme).toBeUndefined();
+  });
+
+  it('does not ask GitHub for a README when upstream declares no repository', async () => {
+    const { client, calls } = fakeUpstream([upstreamEntry({ repository: undefined })]);
+
+    await runIngest(baseOptions(client, fakePrisma(state)));
+
+    expect(calls.readme).toBe(0);
   });
 
   it('skips a server it already holds without downloading anything', async () => {

--- a/apps/registry/tests/mcp-registry-readme.test.ts
+++ b/apps/registry/tests/mcp-registry-readme.test.ts
@@ -106,6 +106,18 @@ describe('fetchGithubReadme', () => {
     expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
   });
 
+  it('measures the cap in bytes, not UTF-16 code units', async () => {
+    // 200k multibyte characters is well under the cap by `.length` and well
+    // over it in bytes. Counting code units would admit several times the
+    // stated bound for any non-ASCII prose.
+    const multibyte = '日'.repeat(200 * 1024);
+    expect(multibyte.length).toBeLessThan(512 * 1024);
+    expect(Buffer.byteLength(multibyte)).toBeGreaterThan(512 * 1024);
+
+    mockFetch(() => ok(multibyte));
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
+  });
+
   it('honours a Content-Length over the cap without reading the body', async () => {
     const spy = mockFetch(
       () =>

--- a/apps/registry/tests/mcp-registry-readme.test.ts
+++ b/apps/registry/tests/mcp-registry-readme.test.ts
@@ -123,10 +123,23 @@ describe('fetchGithubReadme', () => {
     expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
   });
 
+  it('tries the lowercase spelling, which the CDN treats as a different path', async () => {
+    // Unlike the in-bundle lookup, which compares case-insensitively, this is a
+    // URL path on a case-sensitive host: `README.md` 404s for a repo whose file
+    // is `readme.md`.
+    mockFetch((url) => (url.endsWith('/readme.md') ? ok('lowercase body') : notFound()));
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBe('lowercase body');
+  });
+
   it('refuses a repo slug that is not owner/repo', async () => {
     const spy = mockFetch(() => ok('# nope'));
     expect(await fetchGithubReadme({ githubRepo: '../../etc/passwd' })).toBeNull();
     expect(await fetchGithubReadme({ githubRepo: 'acme/widget/extra' })).toBeNull();
+    // Two dot segments are a legal *shape* — both sides match the character
+    // class — so the shape check alone lets this through. `githubSlug` builds
+    // the slug by regex-matching an upstream URL rather than parsing it, so
+    // `https://github.com/../..` really does arrive here.
+    expect(await fetchGithubReadme({ githubRepo: '../..' })).toBeNull();
     expect(spy).not.toHaveBeenCalled();
   });
 

--- a/apps/registry/tests/mcp-registry-readme.test.ts
+++ b/apps/registry/tests/mcp-registry-readme.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The second README source, used only when a mirrored bundle ships none.
+ *
+ * The assertions that matter here are about restraint: it must prefer the ref
+ * the artifact was published at, must never fail an ingest, and must not build
+ * a URL out of an upstream-controlled string without checking its shape.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchGithubReadme, releaseTagFromAssetUrl } from '../src/services/mcp-registry/readme.js';
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>) {
+  const spy = vi.fn((input: string | URL) => Promise.resolve(handler(String(input))));
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+function ok(body: string): Response {
+  return new Response(body, { status: 200 });
+}
+
+function notFound(): Response {
+  return new Response('404: Not Found', { status: 404 });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('releaseTagFromAssetUrl', () => {
+  it('recovers the tag from a GitHub release asset URL', () => {
+    expect(
+      releaseTagFromAssetUrl(
+        'https://github.com/acme/widget/releases/download/v1.1.8/widget-1.1.8.mcpb',
+      ),
+    ).toBe('v1.1.8');
+  });
+
+  it('decodes a percent-encoded tag', () => {
+    expect(
+      releaseTagFromAssetUrl('https://github.com/acme/widget/releases/download/v1%2F2/w.mcpb'),
+    ).toBe('v1/2');
+  });
+
+  it('returns undefined for a URL that is not a release asset', () => {
+    expect(releaseTagFromAssetUrl('https://example.com/downloads/widget.mcpb')).toBeUndefined();
+    expect(releaseTagFromAssetUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe('fetchGithubReadme', () => {
+  it('reads from the raw CDN, not the rate-limited API', async () => {
+    // The registry holds no GitHub token, so the API's 60/hour budget is shared
+    // with claim verification — a user-facing flow. A nightly run over the whole
+    // upstream catalog would consume it in the first minute.
+    const spy = mockFetch(() => ok('# Widget'));
+    await fetchGithubReadme({ githubRepo: 'acme/widget' });
+
+    expect(spy).toHaveBeenCalled();
+    for (const call of spy.mock.calls) {
+      expect(String(call[0])).toMatch(/^https:\/\/raw\.githubusercontent\.com\//);
+      expect(String(call[0])).not.toMatch(/api\.github\.com/);
+    }
+  });
+
+  it('prefers the release tag over the default branch', async () => {
+    const spy = mockFetch((url) =>
+      url.includes('/v1.1.8/') ? ok('# At the tag') : ok('# At HEAD'),
+    );
+
+    const readme = await fetchGithubReadme({ githubRepo: 'acme/widget', ref: 'v1.1.8' });
+
+    expect(readme).toBe('# At the tag');
+    expect(String(spy.mock.calls[0]?.[0])).toBe(
+      'https://raw.githubusercontent.com/acme/widget/v1.1.8/README.md',
+    );
+  });
+
+  it('falls back to HEAD when the tag has no README', async () => {
+    mockFetch((url) => (url.includes('/HEAD/') ? ok('# At HEAD') : notFound()));
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget', ref: 'v1.1.8' })).toBe('# At HEAD');
+  });
+
+  it('tries other README spellings', async () => {
+    mockFetch((url) => (url.endsWith('README.rst') ? ok('rst body') : notFound()));
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBe('rst body');
+  });
+
+  it('returns null when the repository has no README', async () => {
+    mockFetch(() => notFound());
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
+  });
+
+  it('returns null rather than throwing when the network fails', async () => {
+    // A nightly run must not abandon a server because someone's repo is
+    // unreachable. Every failure here is best-effort by construction.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('ECONNRESET'))),
+    );
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
+  });
+
+  it('drops a response larger than the cap', async () => {
+    mockFetch(() => ok('a'.repeat(600 * 1024)));
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
+  });
+
+  it('honours a Content-Length over the cap without reading the body', async () => {
+    const spy = mockFetch(
+      () =>
+        new Response('short', {
+          status: 200,
+          headers: { 'content-length': String(10 * 1024 * 1024) },
+        }),
+    );
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('treats a whitespace-only README as absent', async () => {
+    mockFetch(() => ok('   \n\n  '));
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget' })).toBeNull();
+  });
+
+  it('refuses a repo slug that is not owner/repo', async () => {
+    const spy = mockFetch(() => ok('# nope'));
+    expect(await fetchGithubReadme({ githubRepo: '../../etc/passwd' })).toBeNull();
+    expect(await fetchGithubReadme({ githubRepo: 'acme/widget/extra' })).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('refuses a ref that could climb out of the repository path', async () => {
+    // The ref comes from an upstream-controlled artifact URL and is placed in
+    // the URL path unescaped, because a branch ref legitimately contains `/`.
+    const spy = mockFetch(() => ok('# nope'));
+    await fetchGithubReadme({ githubRepo: 'acme/widget', ref: '../../other/repo' });
+
+    for (const call of spy.mock.calls) {
+      expect(String(call[0])).not.toContain('..');
+    }
+  });
+});

--- a/apps/registry/tests/package.repository.test.ts
+++ b/apps/registry/tests/package.repository.test.ts
@@ -118,6 +118,49 @@ describe('PackageRepository.upsertPackage', () => {
  * Reading both from one row means either a running scan is invisible or a
  * failed one blanks a level the bundle earned.
  */
+describe('PackageRepository.upsertVersion', () => {
+  function makeVersionTx() {
+    const upsert = vi.fn().mockResolvedValue({ id: 'ver-1', version: '1.0.0' });
+    const findUnique = vi.fn().mockResolvedValue({ id: 'ver-1', version: '1.0.0' });
+    const tx = { packageVersion: { upsert, findUnique } } as unknown as TransactionClient;
+    return { tx, upsert, findUnique };
+  }
+
+  const versionData = {
+    packageId: 'pkg-1',
+    version: '1.0.0',
+    manifest: { name: 'widget' },
+    publishMethod: 'ingest',
+  };
+
+  it('writes the README on the update path, not only on create', async () => {
+    // Same class of drift as the empty `update: {}` above. Both callers reach
+    // this path holding a README they already paid for — ingest by opening the
+    // archive, the publish route by spending one of 60 hourly GitHub calls —
+    // and an omission here discards it silently, after the cost.
+    const { tx, upsert } = makeVersionTx();
+
+    await new PackageRepository().upsertVersion(
+      'pkg-1',
+      { ...versionData, readme: '# Widget' },
+      tx,
+    );
+
+    expect(upsert.mock.calls[0]?.[0].update).toMatchObject({ readme: '# Widget' });
+  });
+
+  it('leaves a stored README alone when the caller found none', async () => {
+    // `undefined` means "I have nothing to say about this field", not "clear
+    // it". A bundle that stops shipping a README must not blank a description
+    // an earlier run already recorded.
+    const { tx, upsert } = makeVersionTx();
+
+    await new PackageRepository().upsertVersion('pkg-1', versionData, tx);
+
+    expect(upsert.mock.calls[0]?.[0].update).not.toHaveProperty('readme');
+  });
+});
+
 describe('PackageRepository.getVersionsWithArtifactsAndScans', () => {
   const version = { id: 'ver-1', packageId: 'pkg-1', version: '1.0.0' };
 


### PR DESCRIPTION
Mirrored packages render as empty pages. `@blackduck/mcp-server` and `@knowtis/knowtis` on staging both show no description at all, and every one of the 38 ingested versions has `readme: null`.

## Why it was empty

The publish path fetches a README from the GitHub API at the release tag (`bundles.ts`); the ingest path has no equivalent and never set the column. Not a regression — it was never wired.

## README, from two sources

**The archive wins.** `inspectBundle` already opens the zip and walks every entry for the manifest and the scanability histogram, so reading a root `README.md` costs no extra network and describes the exact bytes whose digest was verified. Root only: bundles vendor dozens of dependency READMEs, and rendering `node_modules/left-pad/README.md` on a package page is worse than rendering nothing.

I measured the corpus by pulling all 38 staging bundles and listing each archive: **14 ship a root README, 19 don't**, 5 I couldn't resolve.

**The declared repository covers the rest**, read from `raw.githubusercontent.com` at the tag recovered from the release-asset URL, falling back to the default branch.

Deliberately **not** the GitHub API. It allows 60 requests/hour unauthenticated, `github-verifier.ts` sends no `Authorization` header and no `GITHUB_TOKEN` exists in config, and that single budget is shared with repo-stat fetches and with **claim verification** — a user-facing flow. A nightly pass over ~305 servers would consume it in the first minute and starve them. The raw host is a CDN and is not charged against it, so this needs no token and no new config.

Best-effort by construction: every failure returns null. A mirror with no description beats a run that abandons a server because someone's repository moved.

## Separately: an artifact shape nobody can download

While measuring the corpus I found 16 of 38 packages 404ing. Most were my own error (the route needs a version), but two are real and permanent:

```
@fmadore/iwac-mcp-server   artifacts: win32/any, darwin/any
@rul1an/assay-mcp-server   artifacts: linux/any
```

`arch: 'any'` is a **stored value, not a query convention** — `inferPlatform` maps `server-linux.mcpb` (an OS token, no arch token) to `linux/any`. No caller can name it:

| Request | Result |
|---|---|
| no params | `resolveArtifact` looks for `any/any` → 404 |
| `os=linux&arch=any` | 422, the query enum is `["x64","arm64"]` |
| `os=linux&arch=x64` | no exact match → 404 |

So the package appears in the catalog and 404s on every download. A caller on a supported platform asks for its concrete pair, so the exact-match lookup never reaches an `os/any` build. (Asking for `arch=any` directly is not a way in either — the query schema admits only `x64`/`arm64` and rejects the request before resolution runs. That rejection also strands the SDK on platforms outside those enums, which is a separate defect: #159.)

Fixed by widening `resolveArtifact` to fall back by decreasing specificity — exact, then the os-universal build, then the fully portable one. Widening the query enum instead would not have helped, since no real client asks for `arch=any`. It stays a 404 when the requested OS has no build at all, so a linux-only package never hands a win32 caller a linux binary.

## Verification

Against real mirrored artifacts, not fixtures:

```
blackduck bundle README: 5626 chars — "# Black Duck MCP", vendored READMEs ignored
gearboy  bundle README: NONE
knowtis  -> tag v0.1.0 -> GitHub README: 12704 chars — "# Knowtis"
```

The two packages from the report resolve through a different source each.

`257/257` registry tests pass, typecheck clean, biome clean. 34 new tests cover root-only matching, case, preference order, the oversize drop, tag-then-HEAD ordering, the CDN-not-API constraint, path-traversal refusal on both the slug and the ref, and each platform-resolution branch.

One fake needed updating: `fakeUpstream` counted every `fetch` as an artifact download, and those counters are how the ingest tests prove idempotence. It now routes by host so a README fetch can't be mistaken for a re-download.

## Scope note

This fills the column going forward. It does **not** backfill staging's existing 38 rows — even `--full` skips them, because `versionIsCurrent` short-circuits on matching digests before any download, and `--full` only widens the `since` window.

That same skip makes a **failed** README resolution permanent, which is worth stating plainly rather than implying otherwise: a row gets whatever was resolvable at the instant of first write, and no later run revisits it. `fetchOne` collapses 404, 429, 5xx, timeout, and DNS failure into the same `null`, so a throttled response is indistinguishable from a genuine absence — and the fallback issues up to 10 sequential unauthenticated requests per README-less server, which is the shape that draws throttling. Staging can be re-ingested from empty; production has ingested nothing yet, so nothing is stuck today. The repair lever is filed as #161 rather than built here: gating `versionIsCurrent` on `readme` would re-download half the catalog nightly forever, and a bespoke full-refresh option is net-new surface for a path used twice a year.

