### PR TITLE
Point docs contributors at mpak-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ Produces a trust score from L1 (Basic) to L4 (Attested) based on which controls 
 
 Documentation site. Covers CLI usage, bundle format, integrations (VS Code, Claude Desktop, Cursor, Claude Code), and security controls.
 
+Content is maintained in [mpak-web](https://github.com/NimbleBrainInc/mpak-web) and serves at [mpak.dev/docs](https://mpak.dev/docs). Edit it there. This copy builds `docs.mpak.dev` until that host is redirected (#163).
+
 ## Development setup
 
 ### Prerequisites

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **These docs have moved.** Content is now maintained in
+> [NimbleBrainInc/mpak-web](https://github.com/NimbleBrainInc/mpak-web) under
+> `src/content/docs/docs/`, which serves it at `mpak.dev/docs`.
+>
+> Edit there, not here. This copy still builds `docs.mpak.dev` until that host
+> is redirected, at which point this directory is deleted.
+
 # mpak Documentation
 
 Documentation site for [mpak](https://mpak.dev), the package registry for agent capabilities.

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -4,7 +4,7 @@
 > `src/content/docs/docs/`, which serves it at `mpak.dev/docs`.
 >
 > Edit there, not here. This copy still builds `docs.mpak.dev` until that host
-> is redirected, at which point this directory is deleted.
+> is redirected, at which point this directory is deleted (#163).
 
 # mpak Documentation
 


### PR DESCRIPTION
Docs content has moved to [mpak-web](https://github.com/NimbleBrainInc/mpak-web) and serves at `mpak.dev/docs`.

This copy still builds `docs.mpak.dev`, so it stays until that host is redirected. The banner exists to stop the two copies forking in the meantime — an edit landing here would be lost when this directory is deleted at cutover. The root README's `apps/docs` section carries the same pointer, since a contributor starting from the repo front page never renders the directory README.

Cutover is tracked in #163.

READMEs only; no build or deploy change.