### PR TITLE
Build the web image against the pinned pnpm

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,7 +21,7 @@ ENV VITE_ENABLE_DEBUG_AUTH=$VITE_ENABLE_DEBUG_AUTH
 
 RUN pnpm --filter @nimblebrain/mpak-web build
 
-RUN pnpm --filter @nimblebrain/mpak-web deploy --prod --legacy /prod
+RUN pnpm --filter @nimblebrain/mpak-web deploy --prod /prod
 
 # Runtime — a Node server rather than nginx, because package and browse routes
 # render per request so crawlers get real HTML instead of an empty shell.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,8 +25,6 @@
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.59.2",
-    "@nimblebrain/mpak-schemas": "workspace:*",
-    "@nimblebrain/mpak-sdk": "workspace:*",
     "@react-router/node": "^8.3.0",
     "@react-router/serve": "^8.3.0",
     "@tailwindcss/postcss": "^4.1.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,12 +138,6 @@ importers:
       '@clerk/clerk-react':
         specifier: ^5.59.2
         version: 5.60.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@nimblebrain/mpak-schemas':
-        specifier: workspace:*
-        version: link:../../packages/schemas
-      '@nimblebrain/mpak-sdk':
-        specifier: workspace:*
-        version: link:../../packages/sdk-typescript
       '@react-router/node':
         specifier: ^8.3.0
         version: 8.3.0(react-router@8.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3)


### PR DESCRIPTION
## What

`pnpm deploy --legacy` is a pnpm 10 flag; the repo pins pnpm 9.15.4, which rejects it as an unknown option. Drop it, and drop two `workspace:*` dependencies `apps/web` declares but never imports (`mpak-schemas`, `mpak-sdk`) — `pnpm deploy` resolves them, and the build stage never copies `packages/`, so they cannot resolve there.

## Why

The web image has never built. CI runs lint, test, and `pnpm build`; none invoke `docker build`, so #164 merged with a Dockerfile that fails at the packaging step. This is only reachable via `make deploy-web`, which is where it surfaced.

Removing the dead declarations is preferred over copying `packages/` into the builder: no commit reachable from `main` has any `src/` reference to either, so the fix is to correct the declaration rather than ship unused packages to satisfy one that was never true.

## Test

Built the image and ran the container against a real registry (staging `mpak-api` port-forwarded):

- boots as uid 1000 (matches `runAsUser: 1000` in the chart values), `/health` 200
- package routes render distinct per-package titles, correct self-canonicals, and `SoftwareApplication` + `BreadcrumbList` JSON-LD — three packages, three distinct response hashes
- `/` server-renders the package list; `/sitemap-packages.xml` emits `registry.mpak.dev` locs
- unknown package and encoded traversal both 404
- with the registry unreachable: package routes 503, `/` stays 200, `/health` stays 200

