### PR TITLE
Point the wordmark at the brand's home

### DIFF
--- a/apps/web/src/layouts/RootLayout.tsx
+++ b/apps/web/src/layouts/RootLayout.tsx
@@ -65,10 +65,16 @@ export default function RootLayout({ children }: RootLayoutProps) {
       <header className="sticky top-0 z-50 bg-[#0c0a0f]/85 backdrop-blur-md border-b border-white/[0.08]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center justify-between">
-            {/* Logo */}
-            <Link to="/" className="flex items-center flex-shrink-0">
+            {/* The wordmark is the brand's mark, so it leads to the brand's home
+                rather than this app's. "Bundles" below is the way back to the
+                registry index. */}
+            <a
+              href={siteConfig.marketingUrl}
+              aria-label="mpak home"
+              className="flex items-center flex-shrink-0"
+            >
               <MpakWordmark />
-            </Link>
+            </a>
 
             {/* Desktop Nav */}
             <nav aria-label="Main navigation" className="hidden md:flex items-center space-x-4">


### PR DESCRIPTION
## What

The registry header's wordmark now links to `mpak.dev` instead of `/`, and carries an `aria-label`.

## Why

The registry and the marketing site are one brand across two hosts, and the wordmark belongs to the brand rather than to this app.

It also removes a redundancy: the wordmark and the "Bundles" nav item both resolved to `/`, so the header had two adjacent links to the same destination. Now the wordmark goes to the brand home and "Bundles" goes to the registry index.

The mark is `aria-hidden`, which left the link with no accessible name at all. That was true before, but it matters more now that the link leaves the origin, so it gets one.

It becomes a plain `<a>` rather than a router `Link` because it crosses origins.

## Test

CI. Verified `siteConfig.marketingUrl` resolves to `https://mpak.dev`, the `Link` import is still used by three other nav items, and `MpakWordmark` appears only in this header.