### PR TITLE
Give Compose its own registry address

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ pnpm --filter @nimblebrain/mpak-registry test
 
 ## Key Conventions
 
-- **API URL**: The web app derives the API URL from `window.location.hostname` at runtime (see `apps/web/src/lib/siteConfig.ts`). No build-time `VITE_API_URL` needed.
+- **API URL**: In the browser the web app calls the API same-origin, so the address is empty. Server-side loaders have no origin to be relative to and read `MPAK_API_URL` at request time (see `apps/web/src/lib/siteConfig.ts`). It is deliberately not a `VITE_` variable: those are inlined at build time, so a value set on a running container would never be seen.
 - **Scoped packages**: All package names are scoped (`@scope/name`)
 - **Prisma**: Registry uses Prisma ORM. Run `npm run db:generate` in `apps/registry/` after schema changes.
 - **Prerender**: Web build includes a prerender step for SEO. Check that all pages succeed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ pnpm --filter @nimblebrain/mpak-registry test
 - **API URL**: In the browser the web app calls the API same-origin, so the address is empty. Server-side loaders have no origin to be relative to and read `MPAK_API_URL` at request time (see `apps/web/src/lib/siteConfig.ts`). It is deliberately not a `VITE_` variable: those are inlined at build time, so a value set on a running container would never be seen.
 - **Scoped packages**: All package names are scoped (`@scope/name`)
 - **Prisma**: Registry uses Prisma ORM. Run `npm run db:generate` in `apps/registry/` after schema changes.
-- **Prerender**: Web build includes a prerender step for SEO. Check that all pages succeed.
+- **Rendering**: Routes are server-rendered (`ssr: true` in `apps/web/react-router.config.ts`), so crawlers get real HTML on first byte.
 
 ## Scanner (Python)
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ See [`apps/web/.env.example`](apps/web/.env.example) for the full list.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VITE_API_URL` | `http://localhost:3200` | Registry API endpoint |
+| `MPAK_API_URL` | `http://localhost:3200` | Registry API endpoint. Read by the server at request time, not baked into the bundle |
 | `VITE_CLERK_PUBLISHABLE_KEY` | (empty) | Clerk public key. Optional for local dev |
 | `VITE_ENABLE_DEBUG_AUTH` | `true` | Show auth debug panel in UI |
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,6 @@
-# API endpoint (must match registry PORT)
-VITE_API_URL=http://localhost:3200
+# Where the server reaches the registry. Defaults to http://localhost:3200,
+# which is the registry's dev port, so this is usually unnecessary locally.
+# MPAK_API_URL=http://localhost:3200
 
 # Auth (optional for local dev)
 VITE_CLERK_PUBLISHABLE_KEY=
@@ -10,9 +11,10 @@ VITE_ENABLE_DEBUG_AUTH=true
 # Google Tag Manager (optional - omit to disable analytics)
 # VITE_GTM_ID=GTM-XXXXXXX
 
-# Site URLs (defaults derive from window.location)
-# VITE_SITE_URL=https://www.mpak.dev
-# VITE_DOCS_URL=https://docs.mpak.dev
+# Site URLs. This app's own origin, and the marketing site it links out to for
+# docs and publishing.
+# VITE_SITE_URL=https://registry.mpak.dev
+# VITE_MARKETING_URL=https://mpak.dev
 
 # Operator branding (defaults to NimbleBrain if unset)
 # Override these to brand the site for your organization.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,8 +34,14 @@ COPY --from=builder /prod/node_modules ./node_modules
 COPY --from=builder /app/apps/web/build ./build
 COPY --from=builder /app/apps/web/package.json ./package.json
 
-# Address the registry Service directly. The public hostname resolves to the
-# ingress, which would route the request back out of the cluster and in again.
+# Server-side loaders have no origin to be relative to, so they need an absolute
+# address, and it must be the registry directly: a public hostname resolves to
+# the proxy in front of this server, sending the request back out and in again.
+#
+# The default is the Service the bundled Helm chart creates, which is the one
+# deployment path that reads it — that chart sets no env on the web pod, so this
+# is where its address comes from. Compose and the deployment repo set their own,
+# naming the Service as each of them does.
 ENV MPAK_API_URL=http://mpak-registry:3200
 ENV PORT=8080
 EXPOSE 8080

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -38,15 +38,16 @@ Copy `.env.example` to `.env` and fill in the values:
 | Variable | Description |
 |----------|-------------|
 | `VITE_CLERK_PUBLISHABLE_KEY` | Clerk publishable key for authentication |
-| `VITE_API_URL` | Backend API URL (defaults to `http://localhost:3000`) |
 | `VITE_ENABLE_DEBUG_AUTH` | Show auth debug panel (`true`/`false`) |
+
+`MPAK_API_URL` addresses the registry from the server. It is set on the running
+container rather than at build time, so it is not a `--build-arg`.
 
 ## Docker
 
 ```bash
 docker build \
   --build-arg VITE_CLERK_PUBLISHABLE_KEY=pk_xxx \
-  --build-arg VITE_API_URL=https://registry.mpak.dev \
   -f apps/web/Dockerfile \
   -t mpak-web .
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -3,7 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_CLERK_PUBLISHABLE_KEY?: string;
   readonly VITE_SITE_URL?: string;
-  readonly VITE_DOCS_URL?: string;
+  readonly VITE_MARKETING_URL?: string;
 }
 
 interface ImportMeta {

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -46,4 +46,6 @@ SCANNER_CALLBACK_SECRET=
 MAX_BUNDLE_SIZE_MB=50
 
 # -- Web App ------------------------------------------------------------------
-VITE_API_URL=https://registry.mpak.dev
+# Where the web server reaches the registry. Compose defaults this to the
+# registry service; set it only if the API runs somewhere else.
+# MPAK_API_URL=http://registry:3200

--- a/deploy/docker/docker-compose.prod.yml
+++ b/deploy/docker/docker-compose.prod.yml
@@ -95,9 +95,11 @@ services:
       context: ../../
       dockerfile: apps/web/Dockerfile
       args:
-        VITE_API_URL: ${VITE_API_URL}
         VITE_CLERK_PUBLISHABLE_KEY: ${VITE_CLERK_PUBLISHABLE_KEY}
         VITE_ENABLE_DEBUG_AUTH: "false"
+    environment:
+      # Read at request time by the server-side loaders.
+      MPAK_API_URL: ${MPAK_API_URL:-http://registry:3200}
     restart: unless-stopped
     ports: ["8080:8080"]
     depends_on: [registry]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -47,9 +47,11 @@ services:
       context: ../../
       dockerfile: apps/web/Dockerfile
       args:
-        VITE_API_URL: http://localhost:3200
         VITE_CLERK_PUBLISHABLE_KEY: ${VITE_CLERK_PUBLISHABLE_KEY:-}
         VITE_ENABLE_DEBUG_AUTH: "true"
+    environment:
+      # Read at request time by the server-side loaders.
+      MPAK_API_URL: ${MPAK_API_URL:-http://registry:3200}
     ports: ["8080:8080"]
     depends_on: [registry]
 


### PR DESCRIPTION
## What

Set `MPAK_API_URL` for the web service in both Compose files, defaulted through the environment. Drop `VITE_API_URL`, replace the stale `VITE_DOCS_URL` declaration with `VITE_MARKETING_URL`, point the commented `VITE_SITE_URL` example at `registry.mpak.dev` to match what `siteConfig` defaults to, and correct the API-URL and rendering notes in `CLAUDE.md`.

## Why

Compose set no `MPAK_API_URL`, so a composed stack inherited the image default — which addresses the Service the bundled Helm chart creates and resolves to nothing on the Compose network. Every server-rendered package route failed. Our cluster is unaffected because its chart values set the variable.

The image default is unchanged. It is not dead: the bundled chart sets no env on its web pod, so it is that path's only source for the address.

`VITE_API_URL` stopped being read when these routes moved to the server but was still a build arg documented across five files. `VITE_DOCS_URL` named a host that no longer resolves; `siteConfig` reads `VITE_MARKETING_URL` instead. The `CLAUDE.md` rendering note described a prerender step the build no longer has.

`VITE_GTM_ID` is untouched here — it holds a live value and is restored in #174.

## Test

CI. Plus: `helm template` shows the chart's Service is `mpak-registry`, matching the retained default; `docker compose config` exits 0 on both files and resolves the address through the new default; no reference to `VITE_API_URL` or `VITE_DOCS_URL` survives.
