### PR TITLE
Load the analytics container again

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ See [`apps/web/.env.example`](apps/web/.env.example) for the full list.
 | `MPAK_API_URL` | `http://localhost:3200` | Registry API endpoint. Read by the server at request time, not baked into the bundle |
 | `VITE_CLERK_PUBLISHABLE_KEY` | (empty) | Clerk public key. Optional for local dev |
 | `VITE_ENABLE_DEBUG_AUTH` | `true` | Show auth debug panel in UI |
+| `VITE_GTM_ID` | (empty) | Google Tag Manager container id. Omit and no analytics is loaded |
 
 ## Deployment
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,8 +16,13 @@ COPY apps/web/ apps/web/
 # the app builds and serves read-only, which is the self-host default.
 ARG VITE_CLERK_PUBLISHABLE_KEY
 ARG VITE_ENABLE_DEBUG_AUTH=false
+# Analytics container id. Public, and inlined into both bundles at build time —
+# the server one emits the tag. Absent it, no tag is emitted and no request is
+# made.
+ARG VITE_GTM_ID
 ENV VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY
 ENV VITE_ENABLE_DEBUG_AUTH=$VITE_ENABLE_DEBUG_AUTH
+ENV VITE_GTM_ID=$VITE_GTM_ID
 
 RUN pnpm --filter @nimblebrain/mpak-web build
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -39,6 +39,7 @@ Copy `.env.example` to `.env` and fill in the values:
 |----------|-------------|
 | `VITE_CLERK_PUBLISHABLE_KEY` | Clerk publishable key for authentication |
 | `VITE_ENABLE_DEBUG_AUTH` | Show auth debug panel (`true`/`false`) |
+| `VITE_GTM_ID` | Google Tag Manager container id. Omit to load no analytics |
 
 `MPAK_API_URL` addresses the registry from the server. It is set on the running
 container rather than at build time, so it is not a `--build-arg`.

--- a/apps/web/src/root.tsx
+++ b/apps/web/src/root.tsx
@@ -38,6 +38,19 @@ function makeQueryClient() {
   });
 }
 
+/**
+ * Google Tag Manager, inlined in the document head so the container loads
+ * before render rather than after hydration.
+ *
+ * The id is checked against the container-id shape because it is interpolated
+ * into a script body: a malformed value would otherwise emit script that either
+ * breaks the page or runs something unintended. Absent or unrecognised, no tag
+ * is emitted and no request is made — which is the self-host default.
+ */
+const GTM_ID = /^GTM-[A-Z0-9]+$/.test(import.meta.env.VITE_GTM_ID ?? '')
+  ? import.meta.env.VITE_GTM_ID
+  : undefined;
+
 let browserQueryClient: QueryClient | undefined;
 
 function getQueryClient() {
@@ -55,8 +68,27 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name="theme-color" content="#0c0a0f" />
         <Meta />
         <Links />
+        {GTM_ID && (
+          <script
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: GTM ships as an inline loader
+            dangerouslySetInnerHTML={{
+              __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${GTM_ID}');`,
+            }}
+          />
+        )}
       </head>
       <body>
+        {GTM_ID && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+              height="0"
+              width="0"
+              style={{ display: 'none', visibility: 'hidden' }}
+              title="Google Tag Manager"
+            />
+          </noscript>
+        )}
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -4,12 +4,9 @@ interface ImportMetaEnv {
   readonly VITE_CLERK_PUBLISHABLE_KEY?: string;
   readonly VITE_SITE_URL?: string;
   readonly VITE_MARKETING_URL?: string;
+  readonly VITE_GTM_ID?: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
-}
-
-interface Window {
-  dataLayer?: Record<string, unknown>[];
 }


### PR DESCRIPTION
## What

Emit the Google Tag Manager snippet from the SSR document head, declare `ARG`/`ENV VITE_GTM_ID` in the Dockerfile, and re-declare the type.

## Why

The registry stopped reporting to GTM when these routes moved to the server. The loader lived in `apps/web/src/main.tsx`, which #164 deleted. Nothing failed — `deployments` kept reading the container id from `op://k8s-production/mpak-web` and passing `--build-arg VITE_GTM_ID`, `apps/web` no longer declared it, Docker warned, and analytics went quiet.

The id is set to a real value in the production vault, so this was live reporting, not dormant config.

Loading from the head rather than reconstructing the old post-hydration injection means the container is available before render.

## Safety

The id is interpolated into an inline script body, so it is validated against `^GTM-[A-Z0-9]+$` first — a malformed value would otherwise emit script that breaks the page or runs something unintended. Absent or unrecognised, no tag is emitted and no request is made, which is the self-host default.

## Test

Built and ran the image both ways:

- `--build-arg VITE_GTM_ID=GTM-TEST1234` → head loader present with that exact id, `noscript` iframe points at `ns.html?id=GTM-TEST1234`, one `gtm.js` reference
- no build arg → **zero** occurrences of `googletagmanager` or `dataLayer` in the served HTML, page renders normally

Fixes #169