### PR TITLE
Announce packages at the host that serves them

### DIFF
--- a/apps/registry/.env.example
+++ b/apps/registry/.env.example
@@ -39,6 +39,10 @@ SCANNER_ENABLED=false
 # OIDC audience for provenance verification (defaults to https://www.mpak.dev)
 # OIDC_AUDIENCE=https://mpak.dev
 
+# Origin where package pages are served, used for links in Discord
+# announcements (defaults to https://registry.mpak.dev)
+# MPAK_PUBLIC_URL=http://localhost:8080
+
 # Discord notifications (optional)
 DISCORD_WEBHOOK_URL=
 

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -93,7 +93,7 @@ pnpm typecheck
 | `HOST` | No | Server host (default: 0.0.0.0) |
 | `NODE_ENV` | No | Environment (development/production) |
 | `CORS_ORIGINS` | No | Comma-separated allowed origins |
-| `MPAK_PUBLIC_URL` | No | Origin where package pages are served, for links in Discord announcements (default: `https://registry.mpak.dev`). The bundled Helm chart derives it from the ingress host |
+| `MPAK_PUBLIC_URL` | No | Origin where package pages are served, for links in Discord announcements (default: `https://registry.mpak.dev`). Under the bundled Helm chart, set it through `registry.env` |
 | `STORAGE_TYPE` | No | Storage backend: local or s3 (default: local) |
 | `STORAGE_PATH` | No | Local storage path (default: ./packages) |
 | `S3_BUCKET` | No | S3 bucket name |

--- a/apps/registry/README.md
+++ b/apps/registry/README.md
@@ -93,6 +93,7 @@ pnpm typecheck
 | `HOST` | No | Server host (default: 0.0.0.0) |
 | `NODE_ENV` | No | Environment (development/production) |
 | `CORS_ORIGINS` | No | Comma-separated allowed origins |
+| `MPAK_PUBLIC_URL` | No | Origin where package pages are served, for links in Discord announcements (default: `https://registry.mpak.dev`). The bundled Helm chart derives it from the ingress host |
 | `STORAGE_TYPE` | No | Storage backend: local or s3 (default: local) |
 | `STORAGE_PATH` | No | Local storage path (default: ./packages) |
 | `S3_BUCKET` | No | S3 bucket name |

--- a/apps/registry/src/config.ts
+++ b/apps/registry/src/config.ts
@@ -12,6 +12,14 @@ export const config = {
       process.env.CORS_ORIGINS?.split(',')
         .map((s) => s.trim())
         .filter(Boolean) || [],
+    // Origin where package pages are served, for links that leave the cluster
+    // and are read by a person — a Discord announcement, say. Such a link can
+    // be neither relative nor an internal Service name.
+    //
+    // Not necessarily this process's own address: here the ingress splits one
+    // host between the API and the pages, but a Compose stack serves them on
+    // separate ports. The bundled chart derives this from its ingress host.
+    publicUrl: (process.env.MPAK_PUBLIC_URL || 'https://registry.mpak.dev').replace(/\/$/, ''),
   },
   metrics: {
     // Prometheus /metrics is served on its own internal port so it is NOT

--- a/apps/registry/src/utils/discord.ts
+++ b/apps/registry/src/utils/discord.ts
@@ -3,6 +3,8 @@
  * Non-blocking notifications for package announcements
  */
 
+import { config } from '../config.js';
+
 const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL || '';
 
 interface AnnounceNotification {
@@ -16,13 +18,14 @@ interface AnnounceNotification {
  * Errors are silently logged, never thrown.
  */
 export function notifyDiscordAnnounce(data: AnnounceNotification): void {
-  const registryUrl = `https://mpak.dev/packages/${encodeURIComponent(data.name)}`;
+  // Package pages are served by the registry, not by the marketing site.
+  const registryUrl = `${config.server.publicUrl}/packages/${encodeURIComponent(data.name)}`;
 
   const content = [
     `**New Bundle Published**`,
     `**${data.name}** v${data.version}`,
     data.repo ? `[GitHub](https://github.com/${data.repo})` : null,
-    `[View on mpak.dev](${registryUrl})`,
+    `[View package](${registryUrl})`,
   ]
     .filter(Boolean)
     .join('\n');

--- a/apps/registry/tests/discord.test.ts
+++ b/apps/registry/tests/discord.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The announcement link is the part of this module that has already been wrong
+ * in production: it pointed at the marketing host after package pages moved to
+ * the registry, and every announcement linked to a 404 without anything
+ * failing. These assertions are about the URL, not the webhook plumbing.
+ *
+ * Both DISCORD_WEBHOOK_URL and the origin are read when the module loads, so
+ * each case stubs the environment and then imports dynamically.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const WEBHOOK = 'https://discord.example/api/webhooks/1/token';
+
+async function announce(env: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  const spy = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
+  vi.stubGlobal('fetch', spy);
+
+  const { notifyDiscordAnnounce } = await import('../src/utils/discord.js');
+  notifyDiscordAnnounce({ name: '@nimblebraininc/echo', version: '1.0.0' });
+  return spy;
+}
+
+function postedContent(spy: ReturnType<typeof vi.fn>): string {
+  const body = spy.mock.calls[0]?.[1]?.body;
+  return JSON.parse(String(body)).content as string;
+}
+
+describe('notifyDiscordAnnounce', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
+  });
+
+  it('links to the host that serves package pages, not the marketing site', async () => {
+    const spy = await announce({ DISCORD_WEBHOOK_URL: WEBHOOK, MPAK_PUBLIC_URL: undefined });
+    const content = postedContent(spy);
+
+    expect(content).toContain('https://registry.mpak.dev/packages/%40nimblebraininc%2Fecho');
+    // The old value, and a substring of the correct one — so it must be
+    // matched with its scheme, not bare.
+    expect(content).not.toContain('https://mpak.dev/packages');
+  });
+
+  it('uses the configured origin, without doubling the separator', async () => {
+    const spy = await announce({
+      DISCORD_WEBHOOK_URL: WEBHOOK,
+      MPAK_PUBLIC_URL: 'https://reg.example.com/',
+    });
+
+    expect(postedContent(spy)).toContain(
+      'https://reg.example.com/packages/%40nimblebraininc%2Fecho',
+    );
+  });
+
+  it('posts nothing when no webhook is configured', async () => {
+    const spy = await announce({ DISCORD_WEBHOOK_URL: undefined });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/deploy/kubernetes/helm/mpak/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/mpak/templates/configmap.yaml
@@ -8,11 +8,6 @@ metadata:
 data:
   CORS_ORIGINS: {{ .Values.config.corsOrigins | quote }}
   S3_REGION: {{ .Values.config.s3Region | quote }}
-  {{- if and .Values.ingress.enabled (not (hasKey .Values.registry.env "MPAK_PUBLIC_URL")) }}
-  {{- /* Derived, not a second knob: the ingress host is already the one value a
-         self-hoster must change, and announcement links have to match it. */}}
-  MPAK_PUBLIC_URL: {{ printf "https://%s" .Values.ingress.registry.host | quote }}
-  {{- end }}
   {{- range $key, $value := .Values.registry.env }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/deploy/kubernetes/helm/mpak/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/mpak/templates/configmap.yaml
@@ -8,6 +8,11 @@ metadata:
 data:
   CORS_ORIGINS: {{ .Values.config.corsOrigins | quote }}
   S3_REGION: {{ .Values.config.s3Region | quote }}
+  {{- if and .Values.ingress.enabled (not (hasKey .Values.registry.env "MPAK_PUBLIC_URL")) }}
+  {{- /* Derived, not a second knob: the ingress host is already the one value a
+         self-hoster must change, and announcement links have to match it. */}}
+  MPAK_PUBLIC_URL: {{ printf "https://%s" .Values.ingress.registry.host | quote }}
+  {{- end }}
   {{- range $key, $value := .Values.registry.env }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}


### PR DESCRIPTION
## What

Build the Discord announcement link from `config.server.publicUrl` (env `MPAK_PUBLIC_URL`, default `https://registry.mpak.dev`) instead of hardcoding `https://mpak.dev`. Document it and cover the URL in tests. Retitle the link, which named the marketing domain too.

## Why

`mpak.dev` served package pages until the registry moved to its own host. It is now a static marketing site with no `/packages/*` route, so every announcement since the cutover has linked to a 404. `DISCORD_WEBHOOK_URL` is set out-of-band in production, so this is live.

Config rather than a second literal: a link leaving the cluster can be neither relative nor an internal Service name. Note the origin is not always this process's own address — the ingress splits one host between the API and the pages, while a Compose stack serves them on separate ports.

The default is the production host, so nothing has to be set there. A self-hoster sets it through the chart's `registry.env`.

## Test

`vitest` 260/260, `tsc --noEmit` clean, `biome check apps/` clean over 126 files. New `tests/discord.test.ts` asserts the link targets the registry host, honours `MPAK_PUBLIC_URL` including a trailing slash, and posts nothing without a webhook. Mutation-checked: restoring the hardcoded literal turns 2 of 3 red.

Not covered by CI, which does not touch helm: `helm lint` clean, and `helm template` renders no `MPAK_PUBLIC_URL` of its own, still emits an explicit `registry.env` entry, and no longer refuses a nil `registry.env`.

Closes #165
