### PR TITLE
fix(registry): never advance the ingest watermark past an unread window

### DIFF
--- a/apps/registry/src/jobs/ingest-mcp-registry.ts
+++ b/apps/registry/src/jobs/ingest-mcp-registry.ts
@@ -82,10 +82,15 @@ export function parseArgs(argv: string[]): CliArgs {
  */
 export function summarizeRun(result: Pick<IngestResult, 'failed' | 'watermark'>): {
   status: 'completed' | 'failed';
-  watermark: Date;
+  watermark: Date | null;
 } {
   return {
     status: result.failed > 0 ? 'failed' : 'completed',
+    // Written through as-is, `null` included. A run that stopped short of the
+    // end of its window has no instant it is safe to resume from, and stores
+    // none; `resolveSince` selects the newest row that has one, so the next run
+    // re-reads from wherever the last *complete* pass reached. Status stays
+    // independent of this — a bounded run did its work and is not a failure.
     watermark: result.watermark,
   };
 }

--- a/apps/registry/src/services/mcp-registry/ingest.ts
+++ b/apps/registry/src/services/mcp-registry/ingest.ts
@@ -150,16 +150,27 @@ export interface IngestResult extends IngestCounters {
   scanability: Record<string, number>;
   failures: Array<{ server: string; error: string }>;
   /**
-   * Lower bound for the next run's window.
+   * Lower bound for the next run's window, or `null` when this run must not
+   * move it at all.
    *
-   * The run's start instant, except that a server which failed for a
-   * *retryable* reason pulls it back to that server's own upstream timestamp.
-   * Without that, the next window opens after the failure and the server falls
-   * outside every subsequent window — one transient 503 would drop a bundle
-   * until someone ran --full. `backoffLimit: 0` on the CronJob means there is
-   * no job-level retry to cover it either.
+   * When the window was read to the end: the run's start instant, except that a
+   * server which failed for a *retryable* reason pulls it back to that server's
+   * own upstream timestamp. Without that, the next window opens after the
+   * failure and the server falls outside every subsequent window — one
+   * transient 503 would drop a bundle until someone ran --full. `backoffLimit:
+   * 0` on the CronJob means there is no job-level retry to cover it either.
+   *
+   * When the window was *not* read to the end, there is no such instant, and
+   * `null` is the only sound answer. Upstream orders by neither name nor
+   * timestamp — `updated_since` is a filter, not a sort — so a stream position
+   * carries no information about which timestamps remain unread. The next
+   * unread entry may be the oldest in the window. That also means the
+   * retryable-failure floor above is itself only valid on a complete pass: it
+   * is a lower bound on unfinished work only because everything below it was
+   * read and succeeded. Truncation invalidates the whole computation, not part
+   * of it.
    */
-  watermark: Date;
+  watermark: Date | null;
 }
 
 /**
@@ -204,6 +215,13 @@ interface ServerOutcome {
  * could sort behind the cursor and never be seen; opening the next window at
  * the start time re-reads that overlap. Re-reading is free because ingest is
  * idempotent, whereas a gap is silent and permanent.
+ *
+ * That holds only for a pass that read its window to the end, so a run which
+ * stopped early returns no watermark at all. Truncation has three causes and
+ * they are defended in three places: upstream misbehaving (the client throws),
+ * a dry run (the job writes no row), and an operator's `--limit` /
+ * `--max-bundles` bound (`watermark: null`, here). All three mean the same
+ * thing — do not advance past what nobody read.
  */
 export async function runIngest(options: IngestOptions): Promise<IngestResult> {
   const { client, since, limit, maxBundles, logger } = options;
@@ -312,29 +330,54 @@ export async function runIngest(options: IngestOptions): Promise<IngestResult> {
 
   let bundlesTaken = 0;
 
-  for await (const entry of client.listServers({ updatedSince: since, version: 'latest' })) {
-    if (limit !== undefined && processed >= limit) break;
-    processed += 1;
+  /**
+   * Read the window, reporting whether it was read to the end.
+   *
+   * A function rather than a flag because "did the stream end on its own?" has
+   * to be a *return value*. `break` continues at the statement after the loop,
+   * so a flag assigned there is assigned on both paths and claims a
+   * completeness that was never reached. Here the only path to `true` is the
+   * iterator running out; every early exit returns `false`, and the return type
+   * will not let a future one forget to say so.
+   */
+  const readWindow = async (): Promise<boolean> => {
+    for await (const entry of client.listServers({ updatedSince: since, version: 'latest' })) {
+      if (limit !== undefined && processed >= limit) return false;
+      processed += 1;
 
-    // Whether a server carries an MCPB bundle is a pure check over metadata
-    // already in hand, so the bundle budget can be spent before any work is
-    // launched — no download is started that the budget would not have allowed.
-    if (maxBundles !== undefined && mcpbPackages(entry).length > 0) {
-      if (bundlesTaken >= maxBundles) break;
-      bundlesTaken += 1;
+      // Whether a server carries an MCPB bundle is a pure check over metadata
+      // already in hand, so the bundle budget can be spent before any work is
+      // launched — no download is started that the budget would not have allowed.
+      if (maxBundles !== undefined && mcpbPackages(entry).length > 0) {
+        if (bundlesTaken >= maxBundles) return false;
+        bundlesTaken += 1;
+      }
+
+      launch(entry);
+      if (inFlight.size >= options.concurrency) await Promise.race(inFlight);
     }
+    return true;
+  };
 
-    launch(entry);
-    if (inFlight.size >= options.concurrency) await Promise.race(inFlight);
-  }
+  const windowDrained = await readWindow();
 
+  // Awaited on both paths: work already launched must still finish and be
+  // counted, so a bounded run reports everything it actually stored.
   await Promise.all(inFlight);
 
   // Each hold was already floored as it was taken, so the oldest one is the
   // answer — capped at the run's start, since a hold in the future would step
   // the window over servers nobody read.
-  const watermark =
-    oldestRetryableFailure && oldestRetryableFailure < runStarted
+  //
+  // None of that applies to a run that stopped early. The floor is a lower
+  // bound on unfinished work only because a complete pass read everything below
+  // it; with servers left unread at arbitrary timestamps, no instant in this
+  // run is safe to resume from, so the run declines to move the watermark at
+  // all. `null` is that refusal, and it is what keeps a trial bound from
+  // stepping the next nightly run over the rest of its window.
+  const watermark = !windowDrained
+    ? null
+    : oldestRetryableFailure && oldestRetryableFailure < runStarted
       ? oldestRetryableFailure
       : runStarted;
 
@@ -342,8 +385,12 @@ export async function runIngest(options: IngestOptions): Promise<IngestResult> {
     ...counters,
     skipReasons,
     scanability,
-    watermark: watermark.toISOString(),
-    watermarkHeldBack: watermark < runStarted,
+    // Load-bearing for an operator reading a bounded run: the counters look
+    // like a successful pass either way, and this is the only thing that says
+    // the window was left unfinished.
+    windowDrained,
+    watermark: watermark?.toISOString() ?? null,
+    watermarkHeldBack: watermark !== null && watermark < runStarted,
   });
 
   return { ...counters, skipReasons, scanability, failures, watermark };

--- a/apps/registry/tests/ingest-job.test.ts
+++ b/apps/registry/tests/ingest-job.test.ts
@@ -61,6 +61,25 @@ describe('summarizeRun', () => {
   it('still surfaces the failure to the operator', () => {
     expect(summarizeRun({ failed: 1, watermark }).status).toBe('failed');
   });
+
+  it('writes a null watermark through rather than substituting one', () => {
+    // A truncated run stores no watermark, so resolveSince — which selects the
+    // newest row that has one — falls back to the last complete pass and
+    // re-reads the window nobody finished. Substituting a value here, or
+    // dropping the key so the column kept its old value on the *new* row, would
+    // both hand the next run a bound that no pass actually earned.
+    expect(summarizeRun({ failed: 0, watermark: null })).toEqual({
+      status: 'completed',
+      watermark: null,
+    });
+  });
+
+  it('does not call a bounded run a failure', () => {
+    // Status and watermark answer different questions. A --max-bundles trial
+    // did exactly what was asked; it just may not move the window. Marking it
+    // failed would page someone for a healthy run.
+    expect(summarizeRun({ failed: 0, watermark: null }).status).toBe('completed');
+  });
 });
 
 describe('validateIngestMemory', () => {

--- a/apps/registry/tests/mcp-registry-ingest.test.ts
+++ b/apps/registry/tests/mcp-registry-ingest.test.ts
@@ -510,6 +510,53 @@ describe('runIngest', () => {
     expect(result.serversMatched).toBe(2);
   });
 
+  it('returns no watermark when a bundle budget cut the window short', async () => {
+    // The bug this guards: a bounded run advanced the watermark to its own
+    // start instant, so every server it never reached fell outside every later
+    // window. Observed on staging — a --max-bundles 10 trial read 617 of 1,803
+    // servers in its window and stepped the next nightly run over the other 45
+    // bundles permanently. Upstream orders by neither name nor timestamp, so
+    // there is no partial instant to resume from; null is the only sound answer.
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      ...upstreamEntry(),
+      server: { ...upstreamEntry().server, name: `io.github.acme/widget-${i}` },
+    }));
+
+    const { client } = fakeUpstream(entries);
+    const result = await runIngest({ ...baseOptions(client, fakePrisma(state)), maxBundles: 2 });
+
+    // The work it did do is still real and still reported.
+    expect(result.packagesCreated).toBe(2);
+    expect(result.watermark).toBeNull();
+  });
+
+  it('returns no watermark when a server limit cut the window short', async () => {
+    // The other bound, same reasoning. Both were `break` statements landing on
+    // a watermark assigned after the loop, which a break reaches too.
+    const entries = Array.from({ length: 5 }, (_, i) => ({
+      ...upstreamEntry(),
+      server: { ...upstreamEntry().server, name: `io.github.acme/widget-${i}` },
+    }));
+
+    const { client } = fakeUpstream(entries);
+    const result = await runIngest({ ...baseOptions(client, fakePrisma(state)), limit: 2 });
+
+    expect(result.watermark).toBeNull();
+  });
+
+  it('advances the watermark when a bound was set but never reached', async () => {
+    // A bound alone must not suppress the watermark — only actually stopping
+    // early does. A nightly run configured with a generous cap it never hits
+    // has read its whole window and has to be able to say so.
+    const { client } = fakeUpstream([upstreamEntry()]);
+
+    const before = new Date();
+    const result = await runIngest({ ...baseOptions(client, fakePrisma(state)), maxBundles: 50 });
+
+    expect(result.packagesCreated).toBe(1);
+    expect(result.watermark?.getTime()).toBeGreaterThanOrEqual(before.getTime());
+  });
+
   it('does not let a bundle budget stop a catalog with no bundles in it', async () => {
     // Servers without an MCPB package never touch the budget, so a trial run
     // walks past them rather than terminating on the first page of npm servers.


### PR DESCRIPTION
## What

A run that stopped short of the end of its window no longer advances the ingest watermark. `IngestResult.watermark` becomes `Date | null`, and `null` means "do not move the window".

## Why

`--limit` and `--max-bundles` `break` out of the paging loop. The watermark was assigned after the loop, which a `break` reaches too — so a bounded run recorded the same watermark as a complete one, and every server it never read fell outside every later window. `oldestRetryableFailure` cannot compensate; only servers that were actually processed feed it.

Caught running a `--max-bundles 10` trial against staging:

| | |
|---|---|
| Servers in the run's window | 1,803 |
| Carrying an MCPB package | 55 |
| Servers the run read | 617 |
| Bundles taken | 10, then `break` |
| Watermark | advanced to the run's start, `watermarkHeldBack: false` |

45 bundle-carrying servers stranded against every future incremental run, reported as `failed: 0`. Same shape as the earlier infra#186 trial, which is why staging held only 38 mirrors.

## Why not hold the watermark where the read stopped

That assumes stream position correlates with timestamp. Sampling 400 entries across four pages of the live upstream window:

```
first 3: 2026-07-27T10:44:51Z, 2026-08-03T10:29:06Z, 2026-08-03T21:57:36Z
last  3: 2026-07-30T20:05:40Z, 2026-08-02T18:43:25Z, 2026-07-31T16:47:50Z
ASCENDING: False    DESCENDING: False
```

`updated_since` is a filter, not a sort, and upstream documents no ordering. The next unread entry may be the oldest in the window, so there is no partial watermark to compute.

What remains is binary, and it covers the retryable-failure floor as much as the start-instant advance — that floor bounds unfinished work only because a complete pass read everything below it:

> The watermark computation is valid only if the whole window was read. Truncation invalidates all of it, not part of it.

## Shape of the fix

Completeness is a **return value**, not a flag. The loop moves into `readWindow(): Promise<boolean>` whose only path to `true` is the iterator running out; every early exit `return`s `false`, and the return type will not let a future one forget to say so.

That is deliberate rather than stylistic. This same invariant is already defended by hand at three other truncation sites — the repeated-cursor throw and the maxPages throw in `client.ts`, and the dry-run "writes no row" in the job — each with a comment stating it in nearly the same words. These two bounds were the fourth site, where re-deriving it was missed. A rule that has to be restated at every site it applies to belongs in the type.

`summarizeRun` writes the `null` through. `resolveSince` already selects the newest row carrying a watermark, so the next run resumes from the last complete pass with no other change. Status stays independent — a bounded run did what was asked and is not a failure.

## Consequence to accept deliberately

A bound can now never make incremental progress. That matches what `maxBundles`' own docstring already claims ("This is the bound you want for a trial run"). Paced backfill cannot be built on the watermark at all given an unordered upstream — it would need a persisted per-server processed set. Worth knowing before anyone adds `--max-bundles` to the CronJob's `extraArgs` expecting it to walk the catalog a night at a time.

## Tests

Both new truncation tests fail against `main` on the exact assertion and pass here:

```
× returns no watermark when a bundle budget cut the window short
× returns no watermark when a server limit cut the window short
✓ advances the watermark when a bound was set but never reached
```

The third passes on both — it guards the over-correction, where a generous bound that is never reached would wrongly suppress the watermark. Plus two on `summarizeRun`: the null is written through, and a bounded run is not marked failed.

Full registry suite: 265 passed. `tsc --noEmit` and `biome check` clean.

## Operational note

Staging needs one `--full` run to recover the 45 skipped servers. Production has never ingested and is unaffected, but its first run must be `--full` rather than a bounded trial.

Closes #181
